### PR TITLE
Bug/quick grid ignore case sort

### DIFF
--- a/examples/MockData/gridData.ts
+++ b/examples/MockData/gridData.ts
@@ -1,4 +1,4 @@
-import { GridColumn } from '../../src/components/QuickGrid/QuickGrid.Props';
+import { GridColumn, DataTypeEnum } from '../../src/components/QuickGrid/QuickGrid.Props';
 
 const RANDOM_WORDS = ['abstrusity', 'advertisable', 'bellwood', 'benzole', 'disputative', 'djilas', 'ebracteate', 'zonary'];
 const RANDOM_Names = ['Ivan', 'Mario', 'Silvio', 'Hrvoje', 'Vinko', 'Marijana', 'Andrea'];
@@ -22,6 +22,7 @@ export const gridColumns1: Array<GridColumn> = [
         headerText: 'Name',
         width: 100
     }, {
+        dataType: DataTypeEnum.String,
         valueMember: 'Color',
         headerText: 'Color',
         width: 100
@@ -43,10 +44,11 @@ export const gridColumns1: Array<GridColumn> = [
 export function getGridData1(numberOfElements): Array<GridData1> {
     let data = [];
     for (let i = 0; i < numberOfElements; i++) {
+        let randomLower = (str : string) => Math.random() > 0.5 ? str : str.toLowerCase();
         data.push(
             {
                 Name: RANDOM_Names[Math.floor(Math.random() * RANDOM_Names.length)],
-                Color: RANDOM_Color[Math.floor(Math.random() * RANDOM_Color.length)],
+                Color:  randomLower(RANDOM_Color[Math.floor(Math.random() * RANDOM_Color.length)]),
                 Animal: RANDOM_Animal[Math.floor(Math.random() * RANDOM_Animal.length)],
                 Mixed: RANDOM_Mix[Math.floor(Math.random() * RANDOM_Mix.length)],
                 Numbers: Math.floor(Math.random() * 30)

--- a/examples/src/QuickGrid.tsx
+++ b/examples/src/QuickGrid.tsx
@@ -9,7 +9,7 @@ import { QuickGrid, IQuickGridProps, SortDirection, GridColumn, QuickGridActions
 import { gridColumns1, getGridData1, gridColumns2, getGridData2 } from '../MockData/gridData';
 import '../../src/components/TreeFilter/TreeFilter.scss'; // used for react-resizable style
 
-const numOfRows = 100;
+const numOfRows = 100000;
 
 
 const gridActions: QuickGridActions = {

--- a/examples/src/QuickGrid.tsx
+++ b/examples/src/QuickGrid.tsx
@@ -9,7 +9,7 @@ import { QuickGrid, IQuickGridProps, SortDirection, GridColumn, QuickGridActions
 import { gridColumns1, getGridData1, gridColumns2, getGridData2 } from '../MockData/gridData';
 import '../../src/components/TreeFilter/TreeFilter.scss'; // used for react-resizable style
 
-const numOfRows = 100000;
+const numOfRows = 100;
 
 
 const gridActions: QuickGridActions = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quick-react-ts",
-  "version": "0.8.57",
+  "version": "0.8.59",
   "description": "Reusable components for React, written in TypeScript",
   "main": "./lib/index.js",
   "typings": "./lib/index",

--- a/src/components/QuickGrid/DataSelectors.ts
+++ b/src/components/QuickGrid/DataSelectors.ts
@@ -15,7 +15,7 @@ const getSortColumn = (state: IQuickGridState, props: IQuickGridProps) => state.
 const getSortDirection = (state: IQuickGridState, props: IQuickGridProps) => state.sortDirection;
 const getColumns = (state: IQuickGridState, props: IQuickGridProps) => props.columns;
 
-const getSortFunctionForColumn = (columns: Array<GridColumn>, sortColumn: GridColumn, sortDirection: SortDirection) => {
+const getSortFunctionForColumn = (sortColumn: GridColumn, sortDirection: SortDirection) => {
     if (sortColumn && sortColumn.sortByValueGetter) {
         let sortValueGetter = sortColumn.sortByValueGetter;
         return (row) => sortValueGetter(row, sortDirection); // (row) => return compareValue
@@ -23,7 +23,7 @@ const getSortFunctionForColumn = (columns: Array<GridColumn>, sortColumn: GridCo
     return null;
 };
 
-const getColumnName = (columns: Array<GridColumn>, sortColumn: GridColumn): string => {
+const getColumnName = (sortColumn: GridColumn): string => {
     if (sortColumn.dataType === DataTypeEnum.String) {
         const lowercasedSortingColumn = lowercasedColumnPrefix + sortColumn.valueMember;
         return lowercasedSortingColumn;
@@ -33,8 +33,8 @@ const getColumnName = (columns: Array<GridColumn>, sortColumn: GridColumn): stri
 
 const getColumnNameAndSortFuntion = (columns: Array<GridColumn>, sortColumnName: string, sortDirection: SortDirection) => {
     const sortColumn = _.find(columns, column => column.valueMember === sortColumnName);
-    const sortFunction = getSortFunctionForColumn(columns, sortColumn, sortDirection);
-    const columnName = getColumnName(columns, sortColumn);
+    const sortFunction = getSortFunctionForColumn(sortColumn, sortDirection);
+    const columnName = getColumnName(sortColumn);
     return { sortFunction: sortFunction, columnName: columnName };
 };
 
@@ -51,7 +51,7 @@ const sortRows = (rows: Array<any>, sortColumnName: string,
         }
         if (sortColumnName) {
             const sortColumn = _.find(columns, column => column.valueMember === sortColumnName);
-            const columnName = getColumnName(columns, sortColumn);
+            const columnName = getColumnName(sortColumn);
             sortOptions.push({ sortModifier: sortModifier, column: columnName });
         }
         return sortArray(rows, sortOptions);

--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -71,7 +71,7 @@ export interface GridColumn {
     headerClassName?: string;
 }
 
-export const sortingColumnsCasePrefix = 'lowercase_';
+export const lowercasedColumnPrefix = 'lowercase_';
 
 export interface QuickGridActions {
     actionItems: Array<ActionItem>;

--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -37,6 +37,7 @@ export interface IQuickGridState {
     columnWidths: Array<number>;
     selectedRowIndex?: number;
     columnsToDisplay: Array<GridColumn>;
+    rows: Array<any>;
 }
 
 export interface GroupRow {
@@ -49,9 +50,16 @@ export interface GroupRow {
     isExpanded: boolean;
 }
 
+export enum DataTypeEnum {
+    Number,
+    String, 
+    Date
+}
+
 export interface GridColumn {
     headerText: string;
     valueMember: string; // for sort & grouping
+    dataType?: DataTypeEnum;
     isSortable?: boolean; // default true
     isGroupable?: boolean; // default true
     sortByValueGetter?: (cellData, sortDirection: SortDirection) => any;
@@ -63,6 +71,7 @@ export interface GridColumn {
     headerClassName?: string;
 }
 
+export const sortingColumnsCasePrefix = 'lowercase_';
 
 export interface QuickGridActions {
     actionItems: Array<ActionItem>;

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -49,13 +49,13 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
             sortColumn: props.sortColumn,
             sortDirection: props.sortDirection,
             groupBy: groupByState,
-            rows: this.modifyInputArray(props.rows, props.columns)
+            rows: this.addLowerCaseMembersToRows(props.rows, props.columns)
         };
         this.columnsMinTotalWidth = columnsToDisplay.map(x => x.minWidth || defaultMinColumnWidth).reduce((a, b) => a + b, 0);
         this.onGridResize = _.debounce(this.onGridResize, 100);
     }
 
-    modifyInputArray = (rows: Array<any>, columns: Array<GridColumn>) => {
+    addLowerCaseMembersToRows = (rows: Array<any>, columns: Array<GridColumn>) => {
         let members = columns.filter(col =>
             (col.dataType === DataTypeEnum.String)).map(col => (col.valueMember));
         const newRows = [...rows].map((row) => {
@@ -121,7 +121,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
             this.setState((oldState) => {
                 return {
                     ...oldState,
-                    rows: this.modifyInputArray(this.props.rows, this.props.columns)
+                    rows: this.addLowerCaseMembersToRows(this.props.rows, this.props.columns)
                 };
             });
         }

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -4,7 +4,7 @@ import * as classNames from 'classnames';
 import { AutoSizer, Table, Column, ColumnProps, ScrollSync, Grid } from 'react-virtualized';
 import {
     IQuickGridProps, IQuickGridState, GridColumn, GroupRow,
-    IGroupBy, SortDirection, DataTypeEnum, sortingColumnsCasePrefix
+    IGroupBy, SortDirection, DataTypeEnum, lowercasedColumnPrefix
 } from './QuickGrid.Props';
 const scrollbarSize = require('dom-helpers/util/scrollbarSize');
 import { getRowsSelector } from './DataSelectors';
@@ -55,14 +55,16 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         this.onGridResize = _.debounce(this.onGridResize, 100);
     }
 
-    modifyInputArray = (rows, columns: Array<GridColumn>) => {
-        let members = columns.filter(col => (col.dataType === DataTypeEnum.String)).map(col => (col.valueMember));
+    modifyInputArray = (rows: Array<any>, columns: Array<GridColumn>) => {
+        let members = columns.filter(col =>
+            (col.dataType === DataTypeEnum.String)).map(col => (col.valueMember));
         const newRows = [...rows].map((row) => {
-            let newObj = { ...row };
+            let modifiedRow = { ...row };
             for (let value of members) {
-                newObj[sortingColumnsCasePrefix + value] = newObj[value].toLowerCase();
+                modifiedRow[lowercasedColumnPrefix + value]
+                    = modifiedRow[value].toLowerCase();
             }
-            return newObj;
+            return modifiedRow;
         });
         return newRows;
     }


### PR DESCRIPTION
Add ignore case sorting to QuickGrid
 - add dataType to IGridColumnProps and DataTypeEnum to QuickGrid.Props.ts
 - if dataType is not passed, the behaviour will not be changed (the sort will work as it used to)
 - add rows to IQuickGridState and use them instead of props.rows (rows in the state will be a copy of props.rows with addition of lowercased columns)
 - ignore case sorting is achieved by sorting over columns that have lowercased values
 - change example to reflect new features