### PR TITLE
QuickGrid optimization

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-draggable": "2.2.3",
     "react-numeric-input": "2.0.7",
     "react-resizable-box": "2.0.6",
-    "react-virtualized": "9.7.3",
+    "react-virtualized": "9.10.1",
     "reselect": "2.5.4",
     "run-sequence": "2.1.0"
   },
@@ -46,7 +46,7 @@
     "@types/node": "8.0.26",
     "@types/react": "16.0.5",
     "@types/react-dom": "15.5.4",
-    "@types/react-virtualized": "9.5.0",
+    "@types/react-virtualized": "9.7.4",
     "awesome-typescript-loader": "3.1.2",
     "babel-core": "6.18.2",
     "babel-polyfill": "6.16.0",

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -16,7 +16,7 @@ export interface IDropdownState {
   isDisabled: boolean;
 }
 
-export class Dropdown extends React.Component<IDropdownProps, IDropdownState> {
+export class Dropdown extends React.PureComponent<IDropdownProps, IDropdownState> {
   public static defaultProps = {
     options: [],
     hasTitleBorder: false,

--- a/src/components/QuickGrid/HeaderColumn.tsx
+++ b/src/components/QuickGrid/HeaderColumn.tsx
@@ -27,7 +27,7 @@ export interface IHeaderColumnProps {
     connectDropTarget?: any;
 }
 
-class HeaderColumnInner extends React.Component<IHeaderColumnProps, void> {
+class HeaderColumnInner extends React.PureComponent<IHeaderColumnProps, void> {
     DragElement = <div style={{ height: 50, width: 30 }} > <span> Drag </span> </div>;
     render() {
         const { className, text, showSortIndicator, sortDirection, onClick, onKeyDown } = this.props;

--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -37,7 +37,6 @@ export interface IQuickGridState {
     columnWidths: Array<number>;
     selectedRowIndex?: number;
     columnsToDisplay: Array<GridColumn>;
-    rows: Array<any>;
 }
 
 export interface GroupRow {

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -238,7 +238,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
     }
 
     onActionItemClick = (option, rowIndex) => {
-        const { onActionSelected, actionIconName, actionItems } = this.props.gridActions;
+        const { onActionSelected, actionItems } = this.props.gridActions;
         if (onActionSelected) {
             const action = actionItems[option.key];
             const rowData = this.finalGridRows[rowIndex];

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -24,7 +24,6 @@ const getActionItemOptions = createSelector([getActionItems], (actionItems) => {
     return actionItems.map((item, index) => ({ key: index, icon: item.iconName, text: item.name }));
 });
 
-
 const defaultMinColumnWidth = 50;
 const emptyCellWidth = 5;
 export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridState> {
@@ -33,6 +32,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         groupBy: [],
         rowHeight: 28
     };
+    private finalGridRows: Array<any>;
     private _grid: any;
     private _headerGrid: any;
     private parentElement: HTMLElement;
@@ -49,25 +49,11 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
             selectedRowIndex: undefined,
             sortColumn: props.sortColumn,
             sortDirection: props.sortDirection,
-            groupBy: groupByState,
-            rows: this.addLowerCaseMembersToRows(props.rows, props.columns)
+            groupBy: groupByState
         };
         this.columnsMinTotalWidth = columnsToDisplay.map(x => x.minWidth || defaultMinColumnWidth).reduce((a, b) => a + b, 0);
         this.onGridResize = _.debounce(this.onGridResize, 100);
-    }
-
-    addLowerCaseMembersToRows = (rows: Array<any>, columns: Array<GridColumn>) => {
-        let members = columns.filter(col =>
-            (col.dataType === DataTypeEnum.String)).map(col => (col.valueMember));
-        const newRows = [...rows].map((row) => {
-            let modifiedRow = { ...row };
-            for (let value of members) {
-                modifiedRow[lowercasedColumnPrefix + value]
-                    = modifiedRow[value].toLowerCase();
-            }
-            return modifiedRow;
-        });
-        return newRows;
+        this.finalGridRows = getRowsSelector(this.state, props);
     }
 
     expandAll = (event) => {
@@ -80,7 +66,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
     }
 
     collapseAll = (event) => {
-        let collapsedRows = this.getAllGroupKeys(this.state.rows);
+        let collapsedRows = this.getAllGroupKeys(this.props.rows);
         this.setState((prevState) => {
             return {
                 ...prevState,
@@ -155,17 +141,9 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
             this.setState((prevState) => { return { ...prevState, columnsToDisplay: columnsToDisplay, columnWidths: columnWidths, groupBy: newGroupBy }; });
             this.columnsMinTotalWidth = columnsToDisplay.map(x => x.minWidth || defaultMinColumnWidth).reduce((a, b) => a + b, 0);
         }
-        if (nextProps.columns !== this.props.columns || nextProps.rows !== this.props.rows) {
-            this.setState((oldState) => {
-                return {
-                    ...oldState,
-                    rows: this.addLowerCaseMembersToRows(this.props.rows, this.props.columns)
-                };
-            });
-        }
     }
-
     componentDidUpdate(prevProps, prevState) {
+        this.finalGridRows = getRowsSelector(this.state, this.props);
         if (prevProps.columns !== this.props.columns || prevState.groupBy !== this.state.groupBy || prevState.columnWidths !== this.state.columnWidths) {
             this._grid.recomputeGridSize();
         } else if (this.state.sortDirection !== prevState.sortDirection || this.state.sortColumn !== prevState.sortColumn) {
@@ -183,20 +161,6 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         // left margin is 25px
         return width - 25 - scrollbarSize();
     }
-
-    getRow = ({ index }) => {
-        const rows = this.getRows();
-        return rows[index % rows.length];
-    }
-
-    getRows() {
-        return getRowsSelector(this.state, this.props);
-    }
-
-    getRowCount = () => {
-        return this.getRows().length;
-    }
-
     onRowExpandToggle(name, shouldExpand) {
         this.setState((oldState) => {
             let collapsedRows = [...oldState.collapsedRows];
@@ -230,8 +194,8 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
     }
 
     cellRenderer = ({ columnIndex, key, rowIndex, style }) => {
-        const rowData = this.getRow({ index: rowIndex });
-        if (rowData.type === 'GroupRow' && this.props.groupBy.length > 0) {
+        const rowData = this.finalGridRows[rowIndex];
+        if (rowData.type === 'GroupRow') { // todo Different member - > true
             return this.renderGroupCell(columnIndex, key, rowIndex, rowData, style);
         } else {
             if (columnIndex === 0 && this.props.gridActions != null) {
@@ -273,19 +237,20 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         );
     }
 
+    onActionItemClick = (option, rowIndex) => {
+        const { onActionSelected, actionIconName, actionItems } = this.props.gridActions;
+        if (onActionSelected) {
+            const action = actionItems[option.key];
+            const rowData = this.finalGridRows[rowIndex];
+            onActionSelected(action.commandName, action.parameters, rowData);
+        }
+    }
     renderActionCell(key, rowIndex: number, rowData, style) {
         const rowClass = 'grid-row-' + rowIndex;
         const onMouseEnter = () => { this.onMouseEnterCell(rowClass); };
         const onMouseLeave = () => { this.onMouseLeaveCell(rowClass); };
         const actionOptions = getActionItemOptions(this.props);
-        const { onActionSelected, actionIconName, actionItems } = this.props.gridActions;
-        const onActionItemClick = (option, index) => {
-            if (onActionSelected) {
-                const action = actionItems[option.key];
-                onActionSelected(action.commandName, action.parameters, rowData);
-            }
-        };
-
+        const { actionIconName } = this.props.gridActions;
         return (
             <div
                 key={key}
@@ -298,7 +263,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                     icon={actionIconName}
                     dropdownType={DropdownType.actionDropdown}
                     displaySelection={false}
-                    onClick={onActionItemClick}
+                    onClick={this.onActionItemClick}
                     options={actionOptions}
                 />
             </div>
@@ -363,8 +328,6 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         const columns = this.state.columnsToDisplay;
         const notLastIndex = columnIndex < (columns.length - 1);
         const column = columns[columnIndex];
-        const width = this.state.columnWidths[columnIndex];
-        const label = column.headerText;
         const dataKey = column.dataMember || column.valueMember;
         const cellData = rowData[dataKey];
         const rowClass = 'grid-row-' + rowIndex;
@@ -452,11 +415,10 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         let headerClass = classNames('grid-component-header', this.props.headerClassName);
         return (
             <div className={mainClass}>
-
-                <ScrollSync>
-                    {({ onScroll, scrollLeft }) => (
-                        <AutoSizer onResize={this.onGridResize}>
-                            {({ height, width }) => (
+                <AutoSizer onResize={this.onGridResize}>
+                    {({ height, width }) => (
+                        <ScrollSync>
+                            {({ onScroll, scrollLeft }) => (
                                 <div style={{ width, height }} >
                                     <GridHeader
                                         ref={this.setHeaderGridReference}
@@ -490,16 +452,17 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                                         columnWidth={this.getColumnWidth}
                                         rowHeight={this.props.rowHeight}
                                         className="grid-component"
-                                        rowCount={this.getRowCount()}
+                                        rowCount={this.finalGridRows.length}
                                         columnCount={this.state.columnsToDisplay.length}
                                         {...this.state} // force update on any state change
                                         {...this.props} // force update on any prop change
                                     />
                                 </div>
                             )}
-                        </AutoSizer>
+                        </ScrollSync>
                     )}
-                </ScrollSync>
+                </AutoSizer>
+
             </div>
         );
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -217,9 +217,9 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-virtualized@9.5.0":
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/@types/react-virtualized/-/react-virtualized-9.5.0.tgz#890c90cc68b0a26d4046a1913881eaeb71bb6c2f"
+"@types/react-virtualized@9.7.4":
+  version "9.7.4"
+  resolved "https://registry.yarnpkg.com/@types/react-virtualized/-/react-virtualized-9.7.4.tgz#c8f8ab729abca03fa76deb0eef820a5daee22129"
   dependencies:
     "@types/react" "*"
 
@@ -867,7 +867,7 @@ babel-register@^6.18.0, babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.9.1:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@^6.9.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -4872,11 +4872,11 @@ react-resizable-box@2.0.6:
   dependencies:
     lodash.isequal "^4.5.0"
 
-react-virtualized@9.7.3:
-  version "9.7.3"
-  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.7.3.tgz#5be2bbc0316151ee1c00d133f7a5f9727874f756"
+react-virtualized@9.10.1:
+  version "9.10.1"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.10.1.tgz#d32365d0edf49debbe25fbfe73b5f55f6d9d8c72"
   dependencies:
-    babel-runtime "^6.11.6"
+    babel-runtime "^6.23.0"
     classnames "^2.2.3"
     dom-helpers "^2.4.0 || ^3.0.0"
     loose-envify "^1.3.0"


### PR DESCRIPTION
- raised react-virtualized version
- rows with lower case members are in row selector, not grid state
- added private field finalGridRows, this removes the row selector call on every cellRenderer
- 