### PR TITLE
Feat/quick grid column footer

### DIFF
--- a/examples/src/QuickGrid.tsx
+++ b/examples/src/QuickGrid.tsx
@@ -27,11 +27,10 @@ const gridActions: QuickGridActions = {
 };
 
 const columnSummaries = {
-    Name: 'Prvi',
-    Color: 'Drugi',
-    Animal: 'Treci',
-    Mixed: 'Cetri',
-    Numbers: 'Pet'
+    Name: 'Craziest: Vinko',
+    Color: 'Best: Orange',
+    Animal: 'Fastest: Dog',
+    Numbers: 'Favorite: 7'
 };
 
 export class Index extends React.Component<any, any> {
@@ -70,7 +69,7 @@ export class Index extends React.Component<any, any> {
                             displayGroupContainer={true}
                             onGroupByChanged={this.groupByChanged}
                             gridActions={gridActions}
-                            // columnSummaries={columnSummaries}
+                            columnSummaries={columnSummaries}
                         />
                     </div>
                 </Resizable>

--- a/examples/src/QuickGrid.tsx
+++ b/examples/src/QuickGrid.tsx
@@ -26,6 +26,14 @@ const gridActions: QuickGridActions = {
     }
 };
 
+const columnSummaries = {
+    Name: 'Prvi',
+    Color: 'Drugi',
+    Animal: 'Treci',
+    Mixed: 'Cetri',
+    Numbers: 'Pet'
+};
+
 export class Index extends React.Component<any, any> {
     state = {
         data: getGridData1(numOfRows),
@@ -62,6 +70,7 @@ export class Index extends React.Component<any, any> {
                             displayGroupContainer={true}
                             onGroupByChanged={this.groupByChanged}
                             gridActions={gridActions}
+                            // columnSummaries={columnSummaries}
                         />
                     </div>
                 </Resizable>

--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -27,6 +27,7 @@ export interface IQuickGridProps {
     groupRowFormat?: (rowData: any) => string;
     onGroupBySort?: (sortBy: string, sortDirection: SortDirection) => void;
     gridActions?: QuickGridActions;
+    columnSummaries?: any;
 }
 
 export interface IQuickGridState {

--- a/src/components/QuickGrid/QuickGrid.scss
+++ b/src/components/QuickGrid/QuickGrid.scss
@@ -94,6 +94,7 @@ $drag-handle-width: 5px;
     .grid-column-footer {
         overflow-y: hidden !important;
         .grid-footer-cell {
+            box-sizing: border-box;
             overflow-y: hidden !important;
             border-top: 2px solid $gray-light-color;
             padding-top: 10px;

--- a/src/components/QuickGrid/QuickGrid.scss
+++ b/src/components/QuickGrid/QuickGrid.scss
@@ -100,8 +100,14 @@ $drag-handle-width: 5px;
             white-space: nowrap;
             text-overflow: ellipsis;
             margin-left: 5px;
+            margin-bottom: 20px;
+            
         }
     }
+}
+
+.grid-component.no-scrollbar {
+    overflow: hidden !important;
 }
 
 .grid-component-header {

--- a/src/components/QuickGrid/QuickGrid.scss
+++ b/src/components/QuickGrid/QuickGrid.scss
@@ -90,6 +90,18 @@ $drag-handle-width: 5px;
     margin-top: 25px;
     margin-left: 25px;
     margin-bottom: 5px;
+
+    .grid-column-footer {
+        .grid-footer-cell {
+            border-top: 2px solid $gray-light-color;
+            display: flex;
+            align-items: center;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            margin-left: 5px;
+        }
+    }
 }
 
 .grid-component-header {

--- a/src/components/QuickGrid/QuickGrid.scss
+++ b/src/components/QuickGrid/QuickGrid.scss
@@ -92,22 +92,22 @@ $drag-handle-width: 5px;
     margin-bottom: 5px;
 
     .grid-column-footer {
+        overflow-y: hidden !important;
         .grid-footer-cell {
+            overflow-y: hidden !important;
             border-top: 2px solid $gray-light-color;
-            display: flex;
-            align-items: center;
+            padding-top: 10px;
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
             margin-left: 5px;
-            margin-bottom: 20px;
             
         }
     }
 }
 
 .grid-component.no-scrollbar {
-    overflow: hidden !important;
+    overflow-x: hidden !important;
 }
 
 .grid-component-header {

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -143,8 +143,12 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
             this.columnsMinTotalWidth = columnsToDisplay.map(x => x.minWidth || defaultMinColumnWidth).reduce((a, b) => a + b, 0);
         }
     }
+
+    componentWillUpdate(nextProps, nextState) {
+        this.finalGridRows = getRowsSelector(nextState, nextProps);
+    }
+
     componentDidUpdate(prevProps, prevState) {
-        this.finalGridRows = getRowsSelector(this.state, this.props);
         if (prevProps.columns !== this.props.columns || prevState.groupBy !== this.state.groupBy || prevState.columnWidths !== this.state.columnWidths) {
             this._grid.recomputeGridSize();
         } else if (this.state.sortDirection !== prevState.sortDirection || this.state.sortColumn !== prevState.sortColumn) {
@@ -152,7 +156,8 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         }
     }
 
-    getGridWidth() {
+
+    getViewportWidth() {
         let width = 0;
         if (document.getElementsByClassName('viewport-height')[0] !== undefined) {
             width = document.getElementsByClassName('viewport-height')[0].clientWidth;
@@ -160,7 +165,11 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
             width = document.getElementById('root').clientWidth;
         }
         // left margin is 25px
-        return width - 25 - scrollbarSize();
+        return width - 25;
+    }
+
+    getGridWidth() {
+        return this.getViewportWidth() - scrollbarSize();
     }
 
     getGridHeight = (height: number) => {
@@ -425,19 +434,13 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         }
     }
 
-    sumColumnMinWidthCallback = (previousValue: number,
-        currentValue: GridColumn,
-        index: number,
-        columns: Array<GridColumn>) => {
-        return previousValue + currentValue.minWidth;
-    }
-
     verticalScrollbarExists() {
-        const columnWidths = this.getColumnWidths(this.state.columnsToDisplay);
-        const gridWidth = this.getGridWidth();
-        return columnWidths.reduce((previous, current, index, columns) => {
+        const columnWidths = this.state.columnWidths;
+        const viewportWidth = this.getViewportWidth();
+        const totalColumnsWidth = columnWidths.reduce((previous, current) => {
             return previous + current;
-        }, 0) >= gridWidth;
+        }, 0);
+        return totalColumnsWidth > viewportWidth;
     }
 
     setHeaderGridReference = (ref) => { this._headerGrid = ref; };
@@ -501,7 +504,6 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                                             columns={this.state.columnsToDisplay}
                                             scrollLeft={scrollLeft}
                                             onScroll={onScroll}
-
                                         />
                                     }
                                 </div>
@@ -509,7 +511,6 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                         </ScrollSync>
                     )}
                 </AutoSizer>
-
             </div>
         );
     }

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -17,6 +17,7 @@ import HTML5Backend from 'react-dnd-html5-backend';
 import { DragDropContextProvider, DragDropContext } from 'react-dnd';
 import { groupBy as arrayGroupBy } from '../../utilities/array';
 const createSelector = require('reselect').createSelector;
+import {GridFooter} from './QuickGridFooter';
 import './QuickGrid.scss';
 
 const getActionItems = (props: IQuickGridProps) => props.gridActions.actionItems;
@@ -444,6 +445,10 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
     groupByToolboxHeight = () => {
         return 30 + (this.props.displayGroupContainer ? 62 : 0); // header height + Drag&Drop height+padding
     }
+
+    columnSummaryContainerHeight = () => {
+        return this.props.columnSummaries ? 40 : 0;
+    }
     setHeaderGridReference = (ref) => { this._headerGrid = ref; };
     setGridReference = (ref) => { this._grid = ref; };
 
@@ -481,7 +486,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
 
                                     <Grid
                                         ref={this.setGridReference}
-                                        height={height - this.groupByToolboxHeight()}
+                                        height={height - this.groupByToolboxHeight() - this.columnSummaryContainerHeight()}
                                         width={width}
                                         onScroll={onScroll}
                                         scrollLeft={scrollLeft}
@@ -495,6 +500,19 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                                         {...this.state} // force update on any state change
                                         {...this.props} // force update on any prop change
                                     />
+                                    {this.props.columnSummaries &&
+                                        <GridFooter
+                                            columns={this.props.columns}
+                                            height={this.columnSummaryContainerHeight()}
+                                            columnWidths={this.state.columnWidths}
+                                            rowData={this.props.columnSummaries}
+                                            width={width}
+                                            columnsToDisplay={this.state.columnsToDisplay}
+                                            scrollLeft={scrollLeft}
+                                            {...this.state}
+                                            {...this.props}
+                                        />
+                                    }
                                 </div>
                             )}
                         </AutoSizer>

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -446,8 +446,8 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         return 30 + (this.props.displayGroupContainer ? 62 : 0); // header height + Drag&Drop height+padding
     }
 
-    columnSummaryContainerHeight = () => {
-        return this.props.columnSummaries ? 40 : 0;
+    gridFooterContainerHeight = () => {
+        return this.props.columnSummaries ? 30 : 0;
     }
     setHeaderGridReference = (ref) => { this._headerGrid = ref; };
     setGridReference = (ref) => { this._grid = ref; };
@@ -486,7 +486,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
 
                                     <Grid
                                         ref={this.setGridReference}
-                                        height={height - this.groupByToolboxHeight() - this.columnSummaryContainerHeight()}
+                                        height={height - this.groupByToolboxHeight() - this.gridFooterContainerHeight()}
                                         width={width}
                                         onScroll={onScroll}
                                         scrollLeft={scrollLeft}
@@ -503,7 +503,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                                     {this.props.columnSummaries &&
                                         <GridFooter
                                             columns={this.props.columns}
-                                            height={this.columnSummaryContainerHeight()}
+                                            height={this.gridFooterContainerHeight()}
                                             columnWidths={this.state.columnWidths}
                                             rowData={this.props.columnSummaries}
                                             width={width}

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -17,7 +17,7 @@ import HTML5Backend from 'react-dnd-html5-backend';
 import { DragDropContextProvider, DragDropContext } from 'react-dnd';
 import { groupBy as arrayGroupBy } from '../../utilities/array';
 const createSelector = require('reselect').createSelector;
-import {GridFooter} from './QuickGridFooter';
+import { GridFooter } from './QuickGridFooter';
 import './QuickGrid.scss';
 
 const getActionItems = (props: IQuickGridProps) => props.gridActions.actionItems;
@@ -447,7 +447,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
     }
 
     gridFooterContainerHeight = () => {
-        return this.props.columnSummaries ? 30 : 0;
+        return this.props.columnSummaries ? 40 : 0;
     }
     setHeaderGridReference = (ref) => { this._headerGrid = ref; };
     setGridReference = (ref) => { this._grid = ref; };
@@ -494,7 +494,8 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                                         overscanRowCount={this.props.overscanRowCount}
                                         columnWidth={this.getColumnWidth}
                                         rowHeight={this.props.rowHeight}
-                                        className="grid-component"
+                                        className={classNames('grid-component',
+                                            { 'no-scrollbar': this.props.columnSummaries })}
                                         rowCount={this.getRowCount()}
                                         columnCount={this.state.columnsToDisplay.length}
                                         {...this.state} // force update on any state change
@@ -502,15 +503,14 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                                     />
                                     {this.props.columnSummaries &&
                                         <GridFooter
-                                            columns={this.props.columns}
                                             height={this.gridFooterContainerHeight()}
                                             columnWidths={this.state.columnWidths}
                                             rowData={this.props.columnSummaries}
                                             width={width}
-                                            columnsToDisplay={this.state.columnsToDisplay}
+                                            columns={this.state.columnsToDisplay}
                                             scrollLeft={scrollLeft}
-                                            {...this.state}
-                                            {...this.props}
+                                            onScroll={onScroll}
+
                                         />
                                     }
                                 </div>

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -162,6 +162,12 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         // left margin is 25px
         return width - 25 - scrollbarSize();
     }
+
+    getGridHeight = (height: number) => {
+        return height - this.groupByToolboxHeight()
+            - this.gridFooterContainerHeight();
+    }
+
     onRowExpandToggle(name, shouldExpand) {
         this.setState((oldState) => {
             let collapsedRows = [...oldState.collapsedRows];
@@ -410,8 +416,30 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
     }
 
     gridFooterContainerHeight = () => {
-        return this.props.columnSummaries ? 40 : 0;
+        if (this.props.columnSummaries) {
+            return 40 + (this.verticalScrollbarExists()
+                ? scrollbarSize()
+                : 0);
+        } else {
+            return 0;
+        }
     }
+
+    sumColumnMinWidthCallback = (previousValue: number,
+        currentValue: GridColumn,
+        index: number,
+        columns: Array<GridColumn>) => {
+        return previousValue + currentValue.minWidth;
+    }
+
+    verticalScrollbarExists() {
+        const columnWidths = this.getColumnWidths(this.state.columnsToDisplay);
+        const gridWidth = this.getGridWidth();
+        return columnWidths.reduce((previous, current, index, columns) => {
+            return previous + current;
+        }, 0) >= gridWidth;
+    }
+
     setHeaderGridReference = (ref) => { this._headerGrid = ref; };
     setGridReference = (ref) => { this._grid = ref; };
 
@@ -448,7 +476,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
 
                                     <Grid
                                         ref={this.setGridReference}
-                                        height={height - this.groupByToolboxHeight() - this.gridFooterContainerHeight()}
+                                        height={this.getGridHeight(height)}
                                         width={width}
                                         onScroll={onScroll}
                                         scrollLeft={scrollLeft}
@@ -469,6 +497,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                                             columnWidths={this.state.columnWidths}
                                             rowData={this.props.columnSummaries}
                                             width={width}
+                                            rowHeight={this.gridFooterContainerHeight() - 2}
                                             columns={this.state.columnsToDisplay}
                                             scrollLeft={scrollLeft}
                                             onScroll={onScroll}

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -426,7 +426,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
 
     gridFooterContainerHeight = () => {
         if (this.props.columnSummaries) {
-            return 40 + (this.verticalScrollbarExists()
+            return 40 + (this.horizontalScrollbarExists()
                 ? scrollbarSize()
                 : 0);
         } else {
@@ -434,7 +434,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         }
     }
 
-    verticalScrollbarExists() {
+    horizontalScrollbarExists() {
         const columnWidths = this.state.columnWidths;
         const viewportWidth = this.getViewportWidth();
         const totalColumnsWidth = columnWidths.reduce((previous, current) => {

--- a/src/components/QuickGrid/QuickGridFooter.tsx
+++ b/src/components/QuickGrid/QuickGridFooter.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { GridColumn, SortDirection, IGroupBy } from './QuickGrid.Props';
+import { shallowCompareArrayEqual } from '../../utilities/array';
+import { Grid } from 'react-virtualized';
+import './QuickGrid.scss';
+
+export interface IGridFooterProps {
+    columnWidths: Array<number>;
+    columns: Array<GridColumn>;
+    columnsToDisplay: Array<GridColumn>;
+    height: number;
+    width: number;
+    rowData: any;
+    scrollLeft: any;
+}
+
+export interface IGridFooterState {
+    columnWidths: Array<number>;
+}
+
+export class GridFooter extends React.PureComponent<IGridFooterProps, IGridFooterState> {
+    private _footerGrid: any;
+    private columnMinWidths: Array<number>;
+    constructor(props: IGridFooterProps) {
+        super(props);
+        this.state = {
+            columnWidths: props.columnWidths
+        };
+        this.columnMinWidths = this.getColumnMinWidths(props.columnsToDisplay);
+    }
+
+    getColumnMinWidths(columns) {
+        return columns.map((col) => { return col.minWidth || 20; });
+    }
+
+    componentWillReceiveProps(nextProps: IGridFooterProps) {
+        if (!shallowCompareArrayEqual(nextProps.columnWidths, this.props.columnWidths)) {
+            this.setState((prevState) => { return { ...prevState, columnWidths: nextProps.columnWidths }; });
+            this.columnMinWidths = this.getColumnMinWidths(nextProps.columnsToDisplay);
+        }
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        this._footerGrid.recomputeGridSize();
+    }
+
+    setGridReference = (ref) => { this._footerGrid = ref; };
+
+    columnSummaryCellRenderer = ({ columnIndex, key, rowIndex, style }): JSX.Element => {
+        const columns = this.props.columnsToDisplay;
+        const notLastIndex = columnIndex < (columns.length - 1);
+        const column = columns[columnIndex];
+        const dataKey = column.dataMember || column.valueMember;
+        const cellData = this.props.rowData[dataKey];
+        const className = classNames(
+            'grid-component-cell',
+            { 'border-column-cell': columnIndex < (this.props.columns.length - 1) }); // ovo je mozda problem
+        return (
+            <div
+                key={key}
+                style={style}
+                className={className}
+            >
+                {cellData}
+            </div>
+        );
+    }
+
+    render() {
+        return (
+            <div style={{ width: this.props.width }}>
+                <Grid
+                    ref={this.setGridReference}
+                    height={this.props.height}
+                    width={this.props.width}
+                    rowHeight={this.props.height - 2}
+                    rowCount={1}
+                    columnCount={this.props.columnsToDisplay.length}
+                    cellRenderer={this.columnSummaryCellRenderer}
+                    columnWidth={({ index }) => this.props.columnWidths[index]}
+                    className="grid-column-footer"
+                    scrollLeft={this.props.scrollLeft}
+                    {...this.props}
+                />
+            </div>);
+    }
+}

--- a/src/components/QuickGrid/QuickGridFooter.tsx
+++ b/src/components/QuickGrid/QuickGridFooter.tsx
@@ -17,32 +17,15 @@ export interface IGridFooterProps {
 }
 
 export interface IGridFooterState {
-    columnWidths: Array<number>;
 }
 
 export class GridFooter extends React.PureComponent<IGridFooterProps, IGridFooterState> {
     private _footerGrid: any;
-    private columnMinWidths: Array<number>;
     constructor(props: IGridFooterProps) {
         super(props);
-        this.state = {
-            columnWidths: props.columnWidths
-        };
-        this.columnMinWidths = this.getColumnMinWidths(props.columns);
-    }
-
-    getColumnMinWidths(columns) {
-        return columns.map((col) => { return col.minWidth || 20; });
     }
 
     getColumnWidth = ({ index }) => this.props.columnWidths[index];
-
-    componentWillReceiveProps(nextProps: IGridFooterProps) {
-        if (!shallowCompareArrayEqual(nextProps.columnWidths, this.props.columnWidths)) {
-            this.setState((prevState) => { return { ...prevState, columnWidths: nextProps.columnWidths }; });
-            this.columnMinWidths = this.getColumnMinWidths(nextProps.columns);
-        }
-    }
 
     componentDidUpdate(prevProps, prevState) {
         this._footerGrid.recomputeGridSize();
@@ -52,7 +35,6 @@ export class GridFooter extends React.PureComponent<IGridFooterProps, IGridFoote
 
     columnSummaryCellRenderer = ({ columnIndex, key, rowIndex, style }): JSX.Element => {
         const columns = this.props.columns;
-        const notLastIndex = columnIndex < (columns.length - 1);
         const column = columns[columnIndex];
         const dataKey = column.dataMember || column.valueMember;
         const cellData = this.props.rowData[dataKey];

--- a/src/components/QuickGrid/QuickGridFooter.tsx
+++ b/src/components/QuickGrid/QuickGridFooter.tsx
@@ -55,7 +55,7 @@ export class GridFooter extends React.PureComponent<IGridFooterProps, IGridFoote
         const cellData = this.props.rowData[dataKey];
         const className = classNames(
             'grid-component-cell',
-            { 'border-column-cell': columnIndex < (this.props.columns.length - 1) }); // ovo je mozda problem
+            'grid-footer-cell');
         return (
             <div
                 key={key}

--- a/src/components/QuickGrid/QuickGridFooter.tsx
+++ b/src/components/QuickGrid/QuickGridFooter.tsx
@@ -9,6 +9,7 @@ export interface IGridFooterProps {
     columnWidths: Array<number>;
     columns: Array<GridColumn>;
     height: number;
+    rowHeight: number;
     width: number;
     rowData: any;
     scrollLeft: any;
@@ -75,7 +76,7 @@ export class GridFooter extends React.PureComponent<IGridFooterProps, IGridFoote
                     ref={this.setGridReference}
                     height={this.props.height}
                     width={this.props.width}
-                    rowHeight={this.props.height - 20}
+                    rowHeight={this.props.rowHeight}
                     rowCount={1}
                     columnCount={this.props.columns.length}
                     cellRenderer={this.columnSummaryCellRenderer}

--- a/src/components/QuickGrid/QuickGridFooter.tsx
+++ b/src/components/QuickGrid/QuickGridFooter.tsx
@@ -8,11 +8,11 @@ import './QuickGrid.scss';
 export interface IGridFooterProps {
     columnWidths: Array<number>;
     columns: Array<GridColumn>;
-    columnsToDisplay: Array<GridColumn>;
     height: number;
     width: number;
     rowData: any;
     scrollLeft: any;
+    onScroll: any;
 }
 
 export interface IGridFooterState {
@@ -27,17 +27,19 @@ export class GridFooter extends React.PureComponent<IGridFooterProps, IGridFoote
         this.state = {
             columnWidths: props.columnWidths
         };
-        this.columnMinWidths = this.getColumnMinWidths(props.columnsToDisplay);
+        this.columnMinWidths = this.getColumnMinWidths(props.columns);
     }
 
     getColumnMinWidths(columns) {
         return columns.map((col) => { return col.minWidth || 20; });
     }
 
+    getColumnWidth = ({ index }) => this.props.columnWidths[index];
+
     componentWillReceiveProps(nextProps: IGridFooterProps) {
         if (!shallowCompareArrayEqual(nextProps.columnWidths, this.props.columnWidths)) {
             this.setState((prevState) => { return { ...prevState, columnWidths: nextProps.columnWidths }; });
-            this.columnMinWidths = this.getColumnMinWidths(nextProps.columnsToDisplay);
+            this.columnMinWidths = this.getColumnMinWidths(nextProps.columns);
         }
     }
 
@@ -48,7 +50,7 @@ export class GridFooter extends React.PureComponent<IGridFooterProps, IGridFoote
     setGridReference = (ref) => { this._footerGrid = ref; };
 
     columnSummaryCellRenderer = ({ columnIndex, key, rowIndex, style }): JSX.Element => {
-        const columns = this.props.columnsToDisplay;
+        const columns = this.props.columns;
         const notLastIndex = columnIndex < (columns.length - 1);
         const column = columns[columnIndex];
         const dataKey = column.dataMember || column.valueMember;
@@ -69,20 +71,20 @@ export class GridFooter extends React.PureComponent<IGridFooterProps, IGridFoote
 
     render() {
         return (
-            <div style={{ width: this.props.width }}>
                 <Grid
                     ref={this.setGridReference}
                     height={this.props.height}
                     width={this.props.width}
-                    rowHeight={this.props.height - 2}
+                    rowHeight={this.props.height - 20}
                     rowCount={1}
-                    columnCount={this.props.columnsToDisplay.length}
+                    columnCount={this.props.columns.length}
                     cellRenderer={this.columnSummaryCellRenderer}
-                    columnWidth={({ index }) => this.props.columnWidths[index]}
+                    columnWidth={this.getColumnWidth}
                     className="grid-column-footer"
                     scrollLeft={this.props.scrollLeft}
+                    onScroll={this.props.onScroll}
                     {...this.props}
                 />
-            </div>);
+        );
     }
 }


### PR DESCRIPTION
Add column footer to QuickGrid

 - column footer should display column summaries
 - QuickGrid now has columnSummaries prop that takes object having column names as properties and string as values
 - if columnSummaries are not provided, QuickGrid behavior will not be changed