### PR TITLE
Add tooltips to QuickGrid

### DIFF
--- a/examples/src/QuickGrid.tsx
+++ b/examples/src/QuickGrid.tsx
@@ -70,6 +70,8 @@ export class Index extends React.Component<any, any> {
                             onGroupByChanged={this.groupByChanged}
                             gridActions={gridActions}
                             columnSummaries={columnSummaries}
+                            actionsTooltip="Act on these."
+                            tooltipsEnabled={true}
                         />
                     </div>
                 </Resizable>

--- a/src/components/QuickGrid/GroupByToolbar.tsx
+++ b/src/components/QuickGrid/GroupByToolbar.tsx
@@ -16,6 +16,7 @@ export interface IGroupByProps {
     onSort: (sortBy: string, sortDirection: SortDirection) => void;
     onCollapseAll: (event) => void;
     onExpandAll: (event) => void;
+    tooltipsEnabled?: boolean;
 
     // Drag&Drop props
     canDrop?: any;
@@ -77,6 +78,7 @@ class GroupByToolbarInner extends React.PureComponent<IGroupByProps, IGroupBySta
                             moveGroupByColumn={this.groupOrderChange}
                             itemArrayIndex={index}
                             removeGroupColumn={this.props.onGroupByRemoved}
+                            tooltipsEnabled={this.props.tooltipsEnabled}
                         />
                     </span>
                     <Icon iconName="icon-delete" className="icon-remove-group" onClick={removeGroup} />

--- a/src/components/QuickGrid/HeaderColumn.tsx
+++ b/src/components/QuickGrid/HeaderColumn.tsx
@@ -37,6 +37,7 @@ class HeaderColumnInner extends React.PureComponent<IHeaderColumnProps, void> {
     render() {
         const { className, text, showSortIndicator, sortDirection, onClick, onKeyDown, tooltipsEnabled } = this.props;
         const sortIcon = sortDirection === SortDirection.Ascending ? 'icon-Arrow_up' : 'icon-arrow_down';
+        const title = tooltipsEnabled ? text : null;
         return (
             this.props.connectDragSource(this.props.connectDropTarget(
                 <div
@@ -48,7 +49,7 @@ class HeaderColumnInner extends React.PureComponent<IHeaderColumnProps, void> {
                     <div className="header-text">
                         <span
                             key="label"
-                            {...tooltipsEnabled ? {title: text} : {} } 
+                            title={title}
                         >
                             {text}
                         </span>

--- a/src/components/QuickGrid/HeaderColumn.tsx
+++ b/src/components/QuickGrid/HeaderColumn.tsx
@@ -20,6 +20,7 @@ export interface IHeaderColumnProps {
     moveGroupByColumn?: (draggedColumn, hoverColumn) => void;
     itemArrayIndex?: number;
     removeGroupColumn?: (columnName) => void;
+    tooltipsEnabled?: boolean;
 
     // Drag&Drop props
     connectDragSource?: any;
@@ -28,9 +29,13 @@ export interface IHeaderColumnProps {
 }
 
 class HeaderColumnInner extends React.PureComponent<IHeaderColumnProps, void> {
+    public static defaultProps = {
+        tooltipsEnabled: true
+    };
+
     DragElement = <div style={{ height: 50, width: 30 }} > <span> Drag </span> </div>;
     render() {
-        const { className, text, showSortIndicator, sortDirection, onClick, onKeyDown } = this.props;
+        const { className, text, showSortIndicator, sortDirection, onClick, onKeyDown, tooltipsEnabled } = this.props;
         const sortIcon = sortDirection === SortDirection.Ascending ? 'icon-Arrow_up' : 'icon-arrow_down';
         return (
             this.props.connectDragSource(this.props.connectDropTarget(
@@ -43,7 +48,7 @@ class HeaderColumnInner extends React.PureComponent<IHeaderColumnProps, void> {
                     <div className="header-text">
                         <span
                             key="label"
-                            title={text}
+                            {...tooltipsEnabled ? {title: text} : {} } 
                         >
                             {text}
                         </span>

--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -28,6 +28,8 @@ export interface IQuickGridProps {
     onGroupBySort?: (sortBy: string, sortDirection: SortDirection) => void;
     gridActions?: QuickGridActions;
     columnSummaries?: any;
+    actionsTooltip?: string;
+    tooltipsEnabled?: boolean;
 }
 
 export interface IQuickGridState {

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -31,7 +31,9 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
     public static defaultProps = {
         overscanRowCount: 20,
         groupBy: [],
-        rowHeight: 28
+        rowHeight: 28,
+        tooltipsEnabled: true,
+        actionsTooltip: 'Actions'
     };
     private finalGridRows: Array<any>;
     private _grid: any;
@@ -263,11 +265,13 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
     }
 
     renderActionCell(key, rowIndex: number, rowData, style) {
+        let { tooltipsEnabled, actionsTooltip } = this.props;
         const rowClass = 'grid-row-' + rowIndex;
         const onMouseEnter = () => { this.onMouseEnterCell(rowClass); };
         const onMouseLeave = () => { this.onMouseLeaveCell(rowClass); };
         const actionOptions = getActionItemOptions(this.props);
         const { actionIconName } = this.props.gridActions;
+        const title = actionsTooltip;
         return (
             <div
                 key={key}
@@ -275,6 +279,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                 className={'grid-component-cell'}
                 onMouseEnter={onMouseEnter}
                 onMouseLeave={onMouseLeave}
+                {...this.props.tooltipsEnabled ? { title } : {} }
             >
                 <Dropdown
                     dropdownKey={rowIndex}
@@ -386,6 +391,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                 onMouseLeave={onMouseLeave}
                 onClick={onClick}
                 onDoubleClick={onDoubleClick}
+                {...this.props.tooltipsEnabled ? { title: cellData } : {} }
             >
                 {columnElement()}
             </div>
@@ -477,6 +483,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                                         hasActionColumn={this.props.gridActions != null}
                                         onCollapseAll={this.collapseAll}
                                         onExpandAll={this.expandAll}
+                                        tooltipsEnabled={this.props.tooltipsEnabled}
                                     />
 
                                     <Grid
@@ -506,6 +513,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                                             columns={this.state.columnsToDisplay}
                                             scrollLeft={scrollLeft}
                                             onScroll={onScroll}
+                                            tooltipsEnabled={this.props.tooltipsEnabled}
                                         />
                                     }
                                 </div>

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -271,7 +271,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         const onMouseLeave = () => { this.onMouseLeaveCell(rowClass); };
         const actionOptions = getActionItemOptions(this.props);
         const { actionIconName } = this.props.gridActions;
-        const title = actionsTooltip;
+        const title = this.props.tooltipsEnabled ? actionsTooltip : null;
         return (
             <div
                 key={key}
@@ -279,7 +279,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                 className={'grid-component-cell'}
                 onMouseEnter={onMouseEnter}
                 onMouseLeave={onMouseLeave}
-                {...this.props.tooltipsEnabled ? { title } : {} }
+                title={title}
             >
                 <Dropdown
                     dropdownKey={rowIndex}
@@ -382,6 +382,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                 );
             }
         };
+        const title = this.props.tooltipsEnabled ? cellData : null; 
         return (
             <div
                 key={key}
@@ -391,7 +392,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                 onMouseLeave={onMouseLeave}
                 onClick={onClick}
                 onDoubleClick={onDoubleClick}
-                {...this.props.tooltipsEnabled ? { title: cellData } : {} }
+                title={title}
             >
                 {columnElement()}
             </div>

--- a/src/components/QuickGrid/QuickGridFooter.tsx
+++ b/src/components/QuickGrid/QuickGridFooter.tsx
@@ -14,6 +14,7 @@ export interface IGridFooterProps {
     rowData: any;
     scrollLeft: any;
     onScroll: any;
+    tooltipsEnabled?: boolean;
 }
 
 export interface IGridFooterState {
@@ -21,6 +22,11 @@ export interface IGridFooterState {
 
 export class GridFooter extends React.PureComponent<IGridFooterProps, IGridFooterState> {
     private _footerGrid: any;
+
+    public static defaultProps = {
+        tooltipsEnabled: true
+    };
+
     constructor(props: IGridFooterProps) {
         super(props);
     }
@@ -46,6 +52,7 @@ export class GridFooter extends React.PureComponent<IGridFooterProps, IGridFoote
                 key={key}
                 style={style}
                 className={className}
+                {...this.props.tooltipsEnabled ? { title: cellData } : {}}
             >
                 {cellData}
             </div>
@@ -54,20 +61,20 @@ export class GridFooter extends React.PureComponent<IGridFooterProps, IGridFoote
 
     render() {
         return (
-                <Grid
-                    ref={this.setGridReference}
-                    height={this.props.height}
-                    width={this.props.width}
-                    rowHeight={this.props.rowHeight}
-                    rowCount={1}
-                    columnCount={this.props.columns.length}
-                    cellRenderer={this.columnSummaryCellRenderer}
-                    columnWidth={this.getColumnWidth}
-                    className="grid-column-footer"
-                    scrollLeft={this.props.scrollLeft}
-                    onScroll={this.props.onScroll}
-                    {...this.props}
-                />
+            <Grid
+                ref={this.setGridReference}
+                height={this.props.height}
+                width={this.props.width}
+                rowHeight={this.props.rowHeight}
+                rowCount={1}
+                columnCount={this.props.columns.length}
+                cellRenderer={this.columnSummaryCellRenderer}
+                columnWidth={this.getColumnWidth}
+                className="grid-column-footer"
+                scrollLeft={this.props.scrollLeft}
+                onScroll={this.props.onScroll}
+                {...this.props}
+            />
         );
     }
 }

--- a/src/components/QuickGrid/QuickGridFooter.tsx
+++ b/src/components/QuickGrid/QuickGridFooter.tsx
@@ -47,12 +47,13 @@ export class GridFooter extends React.PureComponent<IGridFooterProps, IGridFoote
         const className = classNames(
             'grid-component-cell',
             'grid-footer-cell');
+        const title = this.props.tooltipsEnabled ? cellData : null;
         return (
             <div
                 key={key}
                 style={style}
                 className={className}
-                {...this.props.tooltipsEnabled ? { title: cellData } : {}}
+                title={title}
             >
                 {cellData}
             </div>

--- a/src/components/QuickGrid/QuickGridHeader.Props.ts
+++ b/src/components/QuickGrid/QuickGridHeader.Props.ts
@@ -18,6 +18,7 @@ export interface IGridHeaderProps {
     hasActionColumn: boolean;
     onCollapseAll: (event) => void;
     onExpandAll: (event) => void;
+    tooltipsEnabled?: boolean;
 }
 
 export interface IGridHeaderState {

--- a/src/components/QuickGrid/QuickGridHeader.tsx
+++ b/src/components/QuickGrid/QuickGridHeader.tsx
@@ -40,7 +40,7 @@ export class GridHeader extends React.PureComponent<IGridHeaderProps, IGridHeade
 
     render() {
         const headerClass = classNames('grid-header', this.props.className);
-        const { allColumns, headerColumns, width, scrollLeft } = this.props;
+        const { allColumns, headerColumns, width, scrollLeft, tooltipsEnabled } = this.props;
         return (
             <div style={{ width }}>
                 {
@@ -53,6 +53,7 @@ export class GridHeader extends React.PureComponent<IGridHeaderProps, IGridHeade
                         onSort={this.props.onGroupBySort}
                         onCollapseAll={this.props.onCollapseAll}
                         onExpandAll={this.props.onExpandAll}
+                        tooltipsEnabled={tooltipsEnabled}
                     />
                 }
                 <Grid
@@ -166,6 +167,7 @@ export class GridHeader extends React.PureComponent<IGridHeaderProps, IGridHeade
                 isGroupable={column.isGroupable}
                 onClick={onClick}
                 onKeyDown={onKeyDown}
+                tooltipsEnabled={this.props.tooltipsEnabled}
             />
         );
     }


### PR DESCRIPTION
 - Grid cells, Header, Action cells and Footer now have tooltips enabled by default
 - cell tooltip shows cell data, action cell tooltip shows actions tooltip
 - tooltips can be disabled via tooltipsEnabled prop in QuickGrid
 - action cells (column) tooltip can be passed via actionsTooltip prop in QuickGrid
 - cells that have their own formatter function have to take of the tooltip on their own