### PR TITLE
fix for a bad treeview hover button callback

### DIFF
--- a/src/components/Treeview/TreeviewItem.tsx
+++ b/src/components/Treeview/TreeviewItem.tsx
@@ -7,6 +7,7 @@ import { CommonComponent } from '../Common/Common';
 import { autobind } from '../../utilities/autobind';
 import { Treeview } from './Treeview';
 import './Treeview.scss';
+import { TreeviewItemHoverBtn } from './treeviewItemHoverBtn';
 
 const expandedIcon: string = 'icon-arrow_down_right';
 const collapsedIcon: string = 'icon-arrow_right';
@@ -79,11 +80,15 @@ export class TreeviewItem extends CommonComponent<ITreeviewItemProps, any> {
                             <div className="treeview-item__icons-container">
                                 {
                                     this.props.item.hoverOverBtn.map((btn, key) => (
-                                        <div key={key} className="treeview-item__icon">
-                                            <Icon iconName={btn.iconName} onClick={btn.callback.bind(this.props.item.id)}></Icon>
-                                        </div>
-                                    )
-                                    )
+                                        <TreeviewItemHoverBtn
+                                            key={key}
+                                            id={this.props.item.id}
+                                            iconName={btn.iconName}
+                                            onClick={btn.callback}
+                                            className="treeview-item__icon"
+
+                                        />
+                                    ))
                                 }
                             </div>
                         }

--- a/src/components/Treeview/treeviewItemHoverBtn.tsx
+++ b/src/components/Treeview/treeviewItemHoverBtn.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import * as classnames from 'classnames';
+import { Icon } from '../Icon/Icon';
+import { autobind } from '../../index';
+
+export interface ITreeviewItemHoverBtnProps {
+    id: string;
+    iconName: string;
+    className?: string;
+    onClick(id: string): void;
+}
+
+export class TreeviewItemHoverBtn extends React.PureComponent<ITreeviewItemHoverBtnProps, {}> {
+
+    @autobind
+    private _onClick() {
+        this.props.onClick(this.props.id);
+    }
+
+    public render(): JSX.Element {
+        return (
+            <Icon
+                className={this.props.className}
+                iconName={this.props.iconName}
+                onClick={this._onClick}
+            />
+        );
+    }
+}


### PR DESCRIPTION
The treeview hover button callback returned wrong id. 
Callback is now called with correct id.