### PR TITLE
Fix index keys on TagContainer

### DIFF
--- a/src/components/TagContainer/TagContainer.tsx
+++ b/src/components/TagContainer/TagContainer.tsx
@@ -30,13 +30,13 @@ export class TagContainer extends React.Component<ITagContainerProps, any> {
                 {
                     tags.length <= 3 &&
                     tags.map((tag, tagIndex) => (
-                        this.renderTag(tag)
+                        this.renderTag(tag, tagIndex)
                     ))
                 }
                 {
                     tags.length > 3 &&
                     tags.map((i) => { return i; }).slice(0, 3).map((tag, tagIndex) => (
-                        this.renderTag(tag)
+                        this.renderTag(tag, tagIndex)
                     ))
                 }
                 {
@@ -47,9 +47,9 @@ export class TagContainer extends React.Component<ITagContainerProps, any> {
         );
     }
 
-    private renderTag(tag: ITag): JSX.Element {
+    private renderTag(tag: ITag, tagIndex: number): JSX.Element {
         return (
-            <div key={tag.display} className="tag">
+            <div key={tagIndex} className="tag">
                 {tag.iconName &&
                     <Icon iconName={tag.iconName} title={tag.tooltip} />}
                 <span


### PR DESCRIPTION
 - Set tagIndex instead of tag display value as key in renderTag function in TagContainer