### PR TITLE
Hover on dropdown element sets dropdown icon color

### DIFF
--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -6,6 +6,14 @@
     outline: none;
     max-width: 250px;
 
+
+    .dropdown-title:hover {
+        cursor: pointer;
+        .icon {
+            color: $primary-hover-color;
+        }
+    }
+
     .dropdown-title-border {
         border-radius: 8px;
         border: 1px solid $black-color-15;


### PR DESCRIPTION
Hovering over dropdown container applies hover style on dropdown icon to correspond with on click behaviour. 