### PR TITLE
Feat/scheduler component

### DIFF
--- a/examples/pages/Scheduler.html
+++ b/examples/pages/Scheduler.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <title>Scheduler</title>  
+  </head>
+  <body>
+    <div id="root"></div>    
+    <script src="Scheduler.js"></script>
+  </body>
+</html>

--- a/examples/src/Scheduler.tsx
+++ b/examples/src/Scheduler.tsx
@@ -15,9 +15,13 @@ export class Index extends React.Component<any, any> {
             schedule: {
                 recurrencePeriod: 2,
                 daysOfWeek: DaysOfWeekEnum.EveryDay,
-                startTime: new Date()
+                startTime: new Date(),
+                sendOnSpecificDays: true,
+                sendOnSpecificWeekDays: false,
+                daysOfMonth: 1,
+                weeksOfMonth: 1
             },
-            selectedScheduleType: 7
+            selectedScheduleType: 7            
         };
     }
     public render() {
@@ -49,6 +53,5 @@ export class Index extends React.Component<any, any> {
         });
     }
 }
-
 
 ReactDOM.render(<Index />, document.getElementById('root'));

--- a/examples/src/Scheduler.tsx
+++ b/examples/src/Scheduler.tsx
@@ -21,7 +21,7 @@ export class Index extends React.Component<any, any> {
                 daysOfMonth: 1,
                 weeksOfMonth: 1
             },
-            selectedScheduleType: 7            
+            selectedScheduleType: 7
         };
     }
     public render() {
@@ -36,6 +36,8 @@ export class Index extends React.Component<any, any> {
                     {...this.state.schedule}
                 />
             </div>
+
+
         );
     }
 

--- a/examples/src/Scheduler.tsx
+++ b/examples/src/Scheduler.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 import { Scheduler } from './../../src/components/Scheduler/Scheduler';
+import { DaysOfWeekEnum } from '../../src/index';
 
 export class Index extends React.Component<any, any> {
     constructor(props) {
@@ -13,6 +14,7 @@ export class Index extends React.Component<any, any> {
         this.state = {
             schedule: {
                 recurrencePeriod: 2,
+                daysOfWeek: DaysOfWeekEnum.EveryDay,
                 startTime: new Date()
             },
             selectedScheduleType: 7
@@ -36,7 +38,7 @@ export class Index extends React.Component<any, any> {
     onScheduleChanged = (schedule) => {
         this.setState({
             ...this.state,
-            schedule: {...schedule}
+            schedule: schedule
         });
     }
 

--- a/examples/src/Scheduler.tsx
+++ b/examples/src/Scheduler.tsx
@@ -1,0 +1,52 @@
+/* tslint:disable:no-console */
+import 'babel-polyfill';
+import 'ts-helpers';
+
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+import { Scheduler } from './../../src/components/Scheduler/Scheduler';
+
+export class Index extends React.Component<any, any> {
+    constructor(props) {
+        super(props);
+        this.state = {
+            schedule: {
+                recurrencePeriod: 2,
+                startTime: new Date()
+            },
+            selectedScheduleType: 7
+        };
+    }
+    public render() {
+
+        return (
+            <div>
+                <Scheduler
+                    selectedScheduleType={this.state.selectedScheduleType}
+                    onScheduleChanged={this.onScheduleChanged}
+                    scheduleTypeChanged={this.onScheduleTypeChanged}
+                    schedule={this.state.schedule}
+                    {...this.state.schedule}
+                />
+            </div>
+        );
+    }
+
+    onScheduleChanged = (schedule) => {
+        this.setState({
+            ...this.state,
+            schedule: {...schedule}
+        });
+    }
+
+    onScheduleTypeChanged = (scheduleType, index) => {
+        this.setState({
+            ...this.state,
+            selectedScheduleType: scheduleType.key
+        });
+    }
+}
+
+
+ReactDOM.render(<Index />, document.getElementById('root'));

--- a/src/components/ChoiceGroup/ChoiceGroup.Props.ts
+++ b/src/components/ChoiceGroup/ChoiceGroup.Props.ts
@@ -13,5 +13,5 @@ export interface IChoiceGroupOption {
     isChecked?: boolean;
     disabled?: boolean;
     isDisabled?: boolean;
-    contentBelow?: JSX.Element;
+    additionalContent?: JSX.Element;
 }

--- a/src/components/ChoiceGroup/ChoiceGroup.Props.ts
+++ b/src/components/ChoiceGroup/ChoiceGroup.Props.ts
@@ -13,4 +13,5 @@ export interface IChoiceGroupOption {
     isChecked?: boolean;
     disabled?: boolean;
     isDisabled?: boolean;
+    contentBelow?: JSX.Element;
 }

--- a/src/components/ChoiceGroup/ChoiceGroup.scss
+++ b/src/components/ChoiceGroup/ChoiceGroup.scss
@@ -22,6 +22,7 @@ $choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
   .option-additional-content {
     margin-left: 20px;
     margin-bottom: 10px;
+    margin-top: 5px;
     &.is-unchecked {
       opacity: 0.5;
       pointer-events:none;

--- a/src/components/ChoiceGroup/ChoiceGroup.scss
+++ b/src/components/ChoiceGroup/ChoiceGroup.scss
@@ -19,7 +19,7 @@ $choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
     opacity: 0;
   }
 
-  .contentBelow {
+  .option-additional-content {
     margin-left: 20px;
     margin-bottom: 10px;
     &.is-unchecked {

--- a/src/components/ChoiceGroup/ChoiceGroup.scss
+++ b/src/components/ChoiceGroup/ChoiceGroup.scss
@@ -19,6 +19,15 @@ $choiceField-transition-timing: cubic-bezier(.4, 0, .23, 1);
     opacity: 0;
   }
 
+  .contentBelow {
+    margin-left: 20px;
+    margin-bottom: 10px;
+    &.is-unchecked {
+      opacity: 0.5;
+      pointer-events:none;
+    }
+  }
+
   .choiceField-field {
     display: flex;
     align-items: center;

--- a/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -84,7 +84,7 @@ export class ChoiceGroup extends React.Component<IChoiceGroupProps, IChoiceGroup
                                 onBlur={this._onBlur.bind(this, option)}
                             />
                             {this._renderField(option)}
-                            {this._renderContentBelowOption(option, keyChecked)}
+                            {this._renderAdditionalOptionContent(option, keyChecked)}
                         </div>
                     ))}
                 </div>
@@ -127,12 +127,12 @@ export class ChoiceGroup extends React.Component<IChoiceGroupProps, IChoiceGroup
         );
     }
 
-    private _renderContentBelowOption(option, keyChecked) {
+    private _renderAdditionalOptionContent(option, keyChecked) {
         return (
-            <div className={classNames('contentBelow',
+            <div className={classNames('option-additional-content',
                 { 'is-unchecked': option.key !== keyChecked })}
             >
-                {option.contentBelow}
+                {option.additionalContent}
             </div>
         );
     }

--- a/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -84,6 +84,13 @@ export class ChoiceGroup extends React.Component<IChoiceGroupProps, IChoiceGroup
                                 onBlur={this._onBlur.bind(this, option)}
                             />
                             {this._renderField(option)}
+                            {option.contentBelow &&
+                                <div className={classNames('contentBelow',
+                                    { 'is-unchecked': option.key !== keyChecked })}
+                                >
+                                    {option.contentBelow}
+                                </div>
+                            }
                         </div>
                     ))}
                 </div>

--- a/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -84,13 +84,7 @@ export class ChoiceGroup extends React.Component<IChoiceGroupProps, IChoiceGroup
                                 onBlur={this._onBlur.bind(this, option)}
                             />
                             {this._renderField(option)}
-                            {option.contentBelow &&
-                                <div className={classNames('contentBelow',
-                                    { 'is-unchecked': option.key !== keyChecked })}
-                                >
-                                    {option.contentBelow}
-                                </div>
-                            }
+                            {this._renderContentBelowOption(option, keyChecked)}
                         </div>
                     ))}
                 </div>
@@ -130,6 +124,16 @@ export class ChoiceGroup extends React.Component<IChoiceGroupProps, IChoiceGroup
                     {option.text}
                 </span>
             </label>
+        );
+    }
+
+    private _renderContentBelowOption(option, keyChecked) {
+        return (
+            <div className={classNames('contentBelow',
+                { 'is-unchecked': option.key !== keyChecked })}
+            >
+                {option.contentBelow}
+            </div>
         );
     }
 

--- a/src/components/DateTimeDropdownPicker/DateTimeDropdownPicker.tsx
+++ b/src/components/DateTimeDropdownPicker/DateTimeDropdownPicker.tsx
@@ -12,6 +12,7 @@ export interface IDateTimeDropdownPickerProps {
     selectedDate: Date;
     onTimeSelectionChanged?: (selectedDateTime: Date) => void;
     className?: string;
+    includeTime?: boolean;
 }
 
 export interface IDateTimeDropDownPickerState {
@@ -52,6 +53,7 @@ export class DateTimeDropdownPicker extends React.PureComponent<IDateTimeDropdow
                         selectedDateTime={selectedDateCached}
                         is24HourFormat={false}
                         onTimeSelectionChanged={this._dateTimeChanged}
+                        includeTime={this.props.includeTime}
                     />
                     <div className="dropdown-buttons-container">
                         <Button className={'button-textual'} onClick={this._cancelClicked}>Close</Button>

--- a/src/components/Scheduler/InnerSchedulers/DailyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/DailyScheduler.tsx
@@ -4,7 +4,7 @@ import { IInnerSchedulerProps } from './InnerScheduler.Props';
 import { ChoiceGroup } from '../../ChoiceGroup/ChoiceGroup';
 import { DaysOfWeekEnum, TextField } from '../../../index';
 
-export class DailyScheduler extends React.Component<IInnerSchedulerProps, any> {
+export class DailyScheduler extends React.Component<IInnerSchedulerProps, {}> {
 
     render() {
         let { recurrencePeriod, daysOfWeek } = this.props.schedule;

--- a/src/components/Scheduler/InnerSchedulers/DailyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/DailyScheduler.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as NumericInput from 'react-numeric-input';
-import { IInnerSchedulerProps } from './InnerScheduler.Props';
+import { IInnerSchedulerProps, DailySheduleOptionEnum } from './InnerScheduler.Props';
 import { ChoiceGroup } from '../../ChoiceGroup/ChoiceGroup';
 import { DaysOfWeekEnum, TextField } from '../../../index';
 
@@ -37,9 +37,7 @@ export class DailyScheduler extends React.Component<IInnerSchedulerProps, {}> {
                         }
                     ]}
                     onChanged={this.onChoiceGroupOptionChanged}
-
                 />
-
             </div>
         );
     }
@@ -76,9 +74,4 @@ export class DailyScheduler extends React.Component<IInnerSchedulerProps, {}> {
         }
         this.props.onScheduleChanged(newSchedule);
     }
-}
-
-export enum DailySheduleOptionEnum {
-    EveryAmountOfDays,
-    EveryWeekday
 }

--- a/src/components/Scheduler/InnerSchedulers/DailyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/DailyScheduler.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import * as NumericInput from 'react-numeric-input';
+import { IInnerSchedulerProps } from './InnerScheduler.Props';
+import { DailySchedule } from '../Scheduler.Props';
+import { ChoiceGroup } from '../../ChoiceGroup/ChoiceGroup';
+import { DaysOfWeekEnum, TextField } from '../../../index';
+
+export class DailyScheduler extends React.PureComponent<IInnerSchedulerProps, any> {
+
+    render() {
+        let { recurrencePeriod, daysOfWeek } = this.props.schedule as DailySchedule;
+
+        return (
+            <div>
+                <ChoiceGroup
+                    options={[
+                        { key: DailySheduleOptionEnum.EveryAmountOfDays.toString(), text: 'Every', checked: daysOfWeek === DaysOfWeekEnum.EveryDay },
+                        { key: DailySheduleOptionEnum.EveryWeekday.toString(), text: 'Every weekday', checked: daysOfWeek === DaysOfWeekEnum.WorkDays }
+                    ]}
+                    onChanged={this.onChoiceGroupOptionChanged}
+
+                />
+                <div>
+                    <TextField
+                        type="number"
+                        value={recurrencePeriod.toString()}
+                        onClick={this.onRecurrencePeriodChanged}
+                        onKeyUp={this.onRecurrencePeriodChanged}
+                    />
+                </div>
+            </div>
+        );
+    }
+
+    onRecurrencePeriodChanged = (e) => {
+        const value = parseInt(e.target.value, 10);
+        const newSchedule = {
+            ...this.props.schedule,
+            recurrencePeriod: value,
+            daysOfWeek: DaysOfWeekEnum.EveryDay
+        };
+        this.props.onScheduleChanged(newSchedule);
+    }
+
+    onChoiceGroupOptionChanged = (value) => {
+        let recurrencePeriod: number;
+        let daysOfWeek: DaysOfWeekEnum;
+        let newSchedule;
+        if (value.key === DailySheduleOptionEnum.EveryAmountOfDays.toString()) {
+            newSchedule = {
+                ...this.props.schedule,
+                daysOfWeek: DaysOfWeekEnum.EveryDay
+            };
+        } else {
+            newSchedule = {
+                ...this.props.schedule,
+                daysOfWeek: DaysOfWeekEnum.WorkDays,
+                recurrencePeriod: 1
+            };
+        }
+
+        this.props.onScheduleChanged(newSchedule);
+    }
+}
+
+export enum DailySheduleOptionEnum {
+    EveryAmountOfDays,
+    EveryWeekday
+}

--- a/src/components/Scheduler/InnerSchedulers/DailyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/DailyScheduler.tsx
@@ -9,31 +9,45 @@ export class DailyScheduler extends React.PureComponent<IInnerSchedulerProps, an
 
     render() {
         let { recurrencePeriod, daysOfWeek } = this.props.schedule as DailySchedule;
+        const choiceOptionText: any = (
+            <div className="choice-item-text">
+                <span>Every</span>
+                <TextField
+                    type="number"
+                    min="1"
+                    value={recurrencePeriod.toString()}
+                    onClick={this.onRecurrencePeriodChanged}
+                    onKeyUp={this.onRecurrencePeriodChanged}
+                />
+                <span>day(s)</span>
+            </div>
+        );
 
         return (
-            <div>
+            <div className="daily-scheduler">
                 <ChoiceGroup
                     options={[
-                        { key: DailySheduleOptionEnum.EveryAmountOfDays.toString(), text: 'Every', checked: daysOfWeek === DaysOfWeekEnum.EveryDay },
-                        { key: DailySheduleOptionEnum.EveryWeekday.toString(), text: 'Every weekday', checked: daysOfWeek === DaysOfWeekEnum.WorkDays }
+                        {
+                            key: DailySheduleOptionEnum.EveryAmountOfDays.toString(),
+                            text: choiceOptionText,
+                            checked: daysOfWeek === DaysOfWeekEnum.EveryDay
+                        },
+                        {
+                            key: DailySheduleOptionEnum.EveryWeekday.toString(),
+                            text: 'Every weekday',
+                            checked: daysOfWeek === DaysOfWeekEnum.WorkDays
+                        }
                     ]}
                     onChanged={this.onChoiceGroupOptionChanged}
 
                 />
-                <div>
-                    <TextField
-                        type="number"
-                        value={recurrencePeriod.toString()}
-                        onClick={this.onRecurrencePeriodChanged}
-                        onKeyUp={this.onRecurrencePeriodChanged}
-                    />
-                </div>
+
             </div>
         );
     }
 
-    onRecurrencePeriodChanged = (e) => {
-        const value = parseInt(e.target.value, 10);
+    onRecurrencePeriodChanged = (input) => {
+        const value = parseInt(input, 10);
         const newSchedule = {
             ...this.props.schedule,
             recurrencePeriod: value,
@@ -58,7 +72,6 @@ export class DailyScheduler extends React.PureComponent<IInnerSchedulerProps, an
                 recurrencePeriod: 1
             };
         }
-
         this.props.onScheduleChanged(newSchedule);
     }
 }

--- a/src/components/Scheduler/InnerSchedulers/DailyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/DailyScheduler.tsx
@@ -1,30 +1,28 @@
 import * as React from 'react';
 import * as NumericInput from 'react-numeric-input';
 import { IInnerSchedulerProps } from './InnerScheduler.Props';
-import { DailySchedule } from '../Scheduler.Props';
 import { ChoiceGroup } from '../../ChoiceGroup/ChoiceGroup';
 import { DaysOfWeekEnum, TextField } from '../../../index';
 
-export class DailyScheduler extends React.PureComponent<IInnerSchedulerProps, any> {
+export class DailyScheduler extends React.Component<IInnerSchedulerProps, any> {
 
     render() {
-        let { recurrencePeriod, daysOfWeek } = this.props.schedule as DailySchedule;
+        let { recurrencePeriod, daysOfWeek } = this.props.schedule;
         const choiceOptionText: any = (
-            <div className="choice-item-text">
+            <div className="choice-item-content">
                 <span>Every</span>
                 <TextField
                     type="number"
                     min="1"
                     value={recurrencePeriod.toString()}
-                    onClick={this.onRecurrencePeriodChanged}
-                    onKeyUp={this.onRecurrencePeriodChanged}
+                    onChanged={this.onRecurrencePeriodChanged}
                 />
                 <span>day(s)</span>
             </div>
         );
 
         return (
-            <div className="daily-scheduler">
+            <div className="daily-scheduler inner-scheduler">
                 <ChoiceGroup
                     options={[
                         {
@@ -48,6 +46,10 @@ export class DailyScheduler extends React.PureComponent<IInnerSchedulerProps, an
 
     onRecurrencePeriodChanged = (input) => {
         const value = parseInt(input, 10);
+        if (value === this.props.schedule.recurrencePeriod) {
+            return;
+        }
+
         const newSchedule = {
             ...this.props.schedule,
             recurrencePeriod: value,

--- a/src/components/Scheduler/InnerSchedulers/HourlyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/HourlyScheduler.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as NumericInput from 'react-numeric-input';
 import { IInnerSchedulerProps } from './InnerScheduler.Props';
 import { TextField } from '../../TextField/TextField';
-export class HourlyScheduler extends React.Component<IInnerSchedulerProps, any> {
+export class HourlyScheduler extends React.Component<IInnerSchedulerProps, {}> {
 
     render() {
         let { recurrencePeriod } = this.props.schedule;

--- a/src/components/Scheduler/InnerSchedulers/HourlyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/HourlyScheduler.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import * as NumericInput from 'react-numeric-input';
+import { IInnerSchedulerProps } from './InnerScheduler.Props';
+import { TextField } from '../../TextField/TextField';
+import { HourlySchedule } from '../Scheduler.Props';
+
+export class HourlyScheduler extends React.PureComponent<IInnerSchedulerProps, any> {
+
+    render() {
+        let { recurrencePeriod } = this.props.schedule as HourlySchedule;
+
+        return (
+            <div>
+                <NumericInput
+                    value={recurrencePeriod}
+                    onChange={this.onRecurrencePeriodChanged}
+                />
+            </div>
+        );
+    }
+
+    onRecurrencePeriodChanged = (value) => {
+        let newSchedule = {
+            ...this.props.schedule,
+            recurrencePeriod: value
+        };
+        this.props.onScheduleChanged(newSchedule);
+    }
+}
+
+

--- a/src/components/Scheduler/InnerSchedulers/HourlyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/HourlyScheduler.tsx
@@ -10,14 +10,15 @@ export class HourlyScheduler extends React.PureComponent<IInnerSchedulerProps, a
         let { recurrencePeriod } = this.props.schedule as HourlySchedule;
 
         return (
-            <div className="hourly-scheduler">
+            <div className="hourly-scheduler textField-container">
+                <span> Every </span>
                 <TextField
                     type="number"
                     min="1"
                     value={recurrencePeriod.toString()}
                     onChanged={this.onRecurrencePeriodChanged}
-                    label="Recurrence period: "
                 />
+                <span> hours </span>
             </div>
         );
     }

--- a/src/components/Scheduler/InnerSchedulers/HourlyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/HourlyScheduler.tsx
@@ -2,29 +2,33 @@ import * as React from 'react';
 import * as NumericInput from 'react-numeric-input';
 import { IInnerSchedulerProps } from './InnerScheduler.Props';
 import { TextField } from '../../TextField/TextField';
-import { HourlySchedule } from '../Scheduler.Props';
-
-export class HourlyScheduler extends React.PureComponent<IInnerSchedulerProps, any> {
+export class HourlyScheduler extends React.Component<IInnerSchedulerProps, any> {
 
     render() {
-        let { recurrencePeriod } = this.props.schedule as HourlySchedule;
+        let { recurrencePeriod } = this.props.schedule;
 
         return (
-            <div className="hourly-scheduler textField-container">
-                <span> Every </span>
-                <TextField
-                    type="number"
-                    min="1"
-                    value={recurrencePeriod.toString()}
-                    onChanged={this.onRecurrencePeriodChanged}
-                />
-                <span> hours </span>
+            <div className="hourly-scheduler inner-scheduler">
+                <div className="textField-container">
+                    <span> Every </span>
+                    <TextField
+                        type="number"
+                        min="1"
+                        value={recurrencePeriod.toString()}
+                        onChanged={this.onRecurrencePeriodChanged}
+                    />
+                    <span> hours </span>
+                </div>
             </div>
         );
     }
 
     onRecurrencePeriodChanged = (input) => {
         const value = parseInt(input, 10);
+        if (value === this.props.schedule.recurrencePeriod) {
+            return;
+        }
+
         let newSchedule = {
             ...this.props.schedule,
             recurrencePeriod: value

--- a/src/components/Scheduler/InnerSchedulers/InnerScheduler.Props.ts
+++ b/src/components/Scheduler/InnerSchedulers/InnerScheduler.Props.ts
@@ -1,0 +1,7 @@
+import {Schedule } from '../Scheduler.Props';
+
+export interface IInnerSchedulerProps {
+    schedule: Schedule;
+    onScheduleChanged: (schedule: Schedule) => void;
+}
+

--- a/src/components/Scheduler/InnerSchedulers/InnerScheduler.Props.ts
+++ b/src/components/Scheduler/InnerSchedulers/InnerScheduler.Props.ts
@@ -1,7 +1,16 @@
-import {Schedule } from '../Scheduler.Props';
+import { Schedule } from '../Scheduler.Props';
 
 export interface IInnerSchedulerProps {
     schedule: Schedule;
     onScheduleChanged: (schedule: Schedule) => void;
 }
 
+export enum DailySheduleOptionEnum {
+    EveryAmountOfDays,
+    EveryWeekday
+}
+
+export enum MonthlySheduleOptionEnum {
+    OnDayOfMonth = '1',
+    OnDayOfWeek = '2'
+}

--- a/src/components/Scheduler/InnerSchedulers/MinutelyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/MinutelyScheduler.tsx
@@ -2,29 +2,34 @@ import * as React from 'react';
 import * as NumericInput from 'react-numeric-input';
 import { IInnerSchedulerProps } from './InnerScheduler.Props';
 import { TextField } from '../../TextField/TextField';
-import { MinutelySchedule } from '../Scheduler.Props';
 
-export class MinutelyScheduler extends React.PureComponent<IInnerSchedulerProps, any> {
+export class MinutelyScheduler extends React.Component<IInnerSchedulerProps, any> {
 
     render() {
-        let { recurrencePeriod } = this.props.schedule as MinutelySchedule;
+        let { recurrencePeriod } = this.props.schedule;
 
         return (
-            <div className="minutely-scheduler textField-container">
-                <span> Every </span>
-                <TextField
-                    type="number"
-                    min="1"
-                    value={recurrencePeriod.toString()}
-                    onChanged={this.onRecurrencePeriodChanged}
-                />
-                <span> minutes </span>
+            <div className="minutely-scheduler inner-scheduler">
+                <div className="textField-container">
+                    <span> Every </span>
+                    <TextField
+                        type="number"
+                        min="1"
+                        value={recurrencePeriod.toString()}
+                        onChanged={this.onRecurrencePeriodChanged}
+                    />
+                    <span> minutes </span>
+                </div>
             </div>
         );
     }
 
     onRecurrencePeriodChanged = (input) => {
         const value = parseInt(input, 10);
+        if (value === this.props.schedule.recurrencePeriod) {
+            return;
+        }
+
         let newSchedule = {
             ...this.props.schedule,
             recurrencePeriod: value

--- a/src/components/Scheduler/InnerSchedulers/MinutelyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/MinutelyScheduler.tsx
@@ -10,14 +10,15 @@ export class MinutelyScheduler extends React.PureComponent<IInnerSchedulerProps,
         let { recurrencePeriod } = this.props.schedule as MinutelySchedule;
 
         return (
-            <div className="minutely-scheduler">
+            <div className="minutely-scheduler textField-container">
+                <span> Every </span>
                 <TextField
                     type="number"
                     min="1"
                     value={recurrencePeriod.toString()}
                     onChanged={this.onRecurrencePeriodChanged}
-                    label="Recurrence period: "
                 />
+                <span> minutes </span>
             </div>
         );
     }

--- a/src/components/Scheduler/InnerSchedulers/MinutelyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/MinutelyScheduler.tsx
@@ -3,7 +3,7 @@ import * as NumericInput from 'react-numeric-input';
 import { IInnerSchedulerProps } from './InnerScheduler.Props';
 import { TextField } from '../../TextField/TextField';
 
-export class MinutelyScheduler extends React.Component<IInnerSchedulerProps, any> {
+export class MinutelyScheduler extends React.Component<IInnerSchedulerProps, {}> {
 
     render() {
         let { recurrencePeriod } = this.props.schedule;

--- a/src/components/Scheduler/InnerSchedulers/MinutelyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/MinutelyScheduler.tsx
@@ -2,15 +2,15 @@ import * as React from 'react';
 import * as NumericInput from 'react-numeric-input';
 import { IInnerSchedulerProps } from './InnerScheduler.Props';
 import { TextField } from '../../TextField/TextField';
-import { HourlySchedule } from '../Scheduler.Props';
+import { MinutelySchedule } from '../Scheduler.Props';
 
-export class HourlyScheduler extends React.PureComponent<IInnerSchedulerProps, any> {
+export class MinutelyScheduler extends React.PureComponent<IInnerSchedulerProps, any> {
 
     render() {
-        let { recurrencePeriod } = this.props.schedule as HourlySchedule;
+        let { recurrencePeriod } = this.props.schedule as MinutelySchedule;
 
         return (
-            <div className="hourly-scheduler">
+            <div className="minutely-scheduler">
                 <TextField
                     type="number"
                     min="1"

--- a/src/components/Scheduler/InnerSchedulers/MonthlyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/MonthlyScheduler.tsx
@@ -5,7 +5,7 @@ import { IInnerSchedulerProps } from './InnerScheduler.Props';
 import { TextField } from '../../TextField/TextField';
 import { MonthlySchedule, DaysOfWeekEnum, WeeksOfMonthEnum, DayOfMonthEnum } from '../Scheduler.Props';
 import { ChoiceGroup } from '../../ChoiceGroup/ChoiceGroup';
-import { DropdownType } from '../../Dropdown/Dropdown.Props';
+import { DropdownType, IDropdownOption } from '../../Dropdown/Dropdown.Props';
 import { Dropdown } from '../../Dropdown/Dropdown';
 
 export class MonthlyScheduler extends React.PureComponent<IInnerSchedulerProps, any> {
@@ -93,13 +93,15 @@ export class MonthlyScheduler extends React.PureComponent<IInnerSchedulerProps, 
                     options={[
                         {
                             key: MonthlySheduleOptionEnum.OnDayOfMonth,
-                            text: dayOfMonthChoiceText,
-                            checked: sendOnSpecificDays
+                            text: 'First option',
+                            checked: sendOnSpecificDays,
+                            contentBelow: dayOfMonthChoiceText
                         },
                         {
                             key: MonthlySheduleOptionEnum.OnDayOfWeek,
-                            text: dayOfWeekChoiceText,
-                            checked: sendOnSpecificWeekDays
+                            text: 'Second option',
+                            checked: sendOnSpecificWeekDays,
+                            contentBelow: dayOfWeekChoiceText
                         }
                     ]}
                     onChanged={this.onChoiceGroupOptionChanged}
@@ -168,7 +170,7 @@ export class MonthlyScheduler extends React.PureComponent<IInnerSchedulerProps, 
         { key: DayOfMonthEnum.Day6, text: '6' },
         { key: DayOfMonthEnum.Day7, text: '7' },
         { key: DayOfMonthEnum.Day8, text: '8' },
-        { key: DayOfMonthEnum.Day8, text: '9' },
+        { key: DayOfMonthEnum.Day9, text: '9' },
         { key: DayOfMonthEnum.Day10, text: '10' },
         { key: DayOfMonthEnum.Day11, text: '11' },
         { key: DayOfMonthEnum.Day12, text: '12' },

--- a/src/components/Scheduler/InnerSchedulers/MonthlyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/MonthlyScheduler.tsx
@@ -1,7 +1,7 @@
 /* tslint:disable:no-bitwise */
 import * as React from 'react';
 import * as NumericInput from 'react-numeric-input';
-import { IInnerSchedulerProps } from './InnerScheduler.Props';
+import { IInnerSchedulerProps, MonthlySheduleOptionEnum } from './InnerScheduler.Props';
 import { TextField } from '../../TextField/TextField';
 import { DaysOfWeekEnum, WeeksOfMonthEnum, DayOfMonthEnum } from '../Scheduler.Props';
 import { ChoiceGroup } from '../../ChoiceGroup/ChoiceGroup';
@@ -198,9 +198,4 @@ export class MonthlyScheduler extends React.Component<IInnerSchedulerProps, {}> 
         { key: DayOfMonthEnum.Day30, text: '30' },
         { key: DayOfMonthEnum.Day31, text: '31' }
     ];
-}
-
-export enum MonthlySheduleOptionEnum {
-    OnDayOfMonth = '1',
-    OnDayOfWeek = '2'
 }

--- a/src/components/Scheduler/InnerSchedulers/MonthlyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/MonthlyScheduler.tsx
@@ -3,12 +3,12 @@ import * as React from 'react';
 import * as NumericInput from 'react-numeric-input';
 import { IInnerSchedulerProps } from './InnerScheduler.Props';
 import { TextField } from '../../TextField/TextField';
-import { MonthlySchedule, DaysOfWeekEnum, WeeksOfMonthEnum, DayOfMonthEnum } from '../Scheduler.Props';
+import { DaysOfWeekEnum, WeeksOfMonthEnum, DayOfMonthEnum } from '../Scheduler.Props';
 import { ChoiceGroup } from '../../ChoiceGroup/ChoiceGroup';
 import { DropdownType, IDropdownOption } from '../../Dropdown/Dropdown.Props';
 import { Dropdown } from '../../Dropdown/Dropdown';
 
-export class MonthlyScheduler extends React.PureComponent<IInnerSchedulerProps, any> {
+export class MonthlyScheduler extends React.Component<IInnerSchedulerProps, any> {
 
     render() {
         let {
@@ -18,10 +18,10 @@ export class MonthlyScheduler extends React.PureComponent<IInnerSchedulerProps, 
             weeksOfMonth,
             daysOfWeek,
             recurrencePeriod
-        } = this.props.schedule as MonthlySchedule;
+        } = this.props.schedule;
 
         const dayOfMonthChoiceText: any = (
-            <div className="choice-item-text">
+            <div className="choice-item-content">
                 <span>Day</span>
                 <Dropdown
                     hasTitleBorder={true}
@@ -42,7 +42,7 @@ export class MonthlyScheduler extends React.PureComponent<IInnerSchedulerProps, 
         );
 
         const dayOfWeekChoiceText: any = (
-            <div className="choice-item-text">
+            <div className="choice-item-content">
                 <span>The</span>
                 <Dropdown
                     hasTitleBorder={true}
@@ -88,18 +88,18 @@ export class MonthlyScheduler extends React.PureComponent<IInnerSchedulerProps, 
 
 
         return (
-            <div className="monthly-scheduler">
+            <div className="monthly-scheduler inner-scheduler">
                 <ChoiceGroup
                     options={[
                         {
                             key: MonthlySheduleOptionEnum.OnDayOfMonth,
-                            text: 'First option',
+                            text: 'On specific day of month',
                             checked: sendOnSpecificDays,
                             contentBelow: dayOfMonthChoiceText
                         },
                         {
                             key: MonthlySheduleOptionEnum.OnDayOfWeek,
-                            text: 'Second option',
+                            text: 'On specific day of week',
                             checked: sendOnSpecificWeekDays,
                             contentBelow: dayOfWeekChoiceText
                         }

--- a/src/components/Scheduler/InnerSchedulers/MonthlyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/MonthlyScheduler.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import * as NumericInput from 'react-numeric-input';
+import { IInnerSchedulerProps } from './InnerScheduler.Props';
+import { TextField } from '../../TextField/TextField';
+import { MonthlySchedule } from '../Scheduler.Props';
+
+export class MonthlyScheduler extends React.PureComponent<IInnerSchedulerProps, any> {
+
+    render() {
+        let { recurrencePeriod } = this.props.schedule as MonthlySchedule;
+
+        return (
+            <div>
+                <NumericInput
+                    value={recurrencePeriod}
+                    onChange={this.onRecurrencePeriodChanged}
+                />
+            </div>
+        );
+    }
+
+    onRecurrencePeriodChanged = (value) => {
+        let newSchedule = {
+            ...this.props.schedule,
+            recurrencePeriod: value
+        };
+        this.props.onScheduleChanged(newSchedule);
+    }
+}
+
+

--- a/src/components/Scheduler/InnerSchedulers/MonthlyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/MonthlyScheduler.tsx
@@ -29,6 +29,7 @@ export class MonthlyScheduler extends React.Component<IInnerSchedulerProps, {}> 
                     onChanged={this.onDayOfMonthChanged}
                     selectedKey={daysOfMonth}
                     dropdownType={DropdownType.selectionDropdown}
+                    calloutClassName="day-of-month-dropdown-callout"
                 />
                 <span>of every</span>
                 <TextField

--- a/src/components/Scheduler/InnerSchedulers/MonthlyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/MonthlyScheduler.tsx
@@ -29,7 +29,7 @@ export class MonthlyScheduler extends React.Component<IInnerSchedulerProps, {}> 
                     onChanged={this.onDayOfMonthChanged}
                     selectedKey={daysOfMonth}
                     dropdownType={DropdownType.selectionDropdown}
-                    calloutClassName="day-of-month-dropdown-callout"
+                    calloutClassName="scheduler-day-of-month-dropdown-callout"
                 />
                 <span>of every</span>
                 <TextField

--- a/src/components/Scheduler/InnerSchedulers/MonthlyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/MonthlyScheduler.tsx
@@ -8,7 +8,7 @@ import { ChoiceGroup } from '../../ChoiceGroup/ChoiceGroup';
 import { DropdownType, IDropdownOption } from '../../Dropdown/Dropdown.Props';
 import { Dropdown } from '../../Dropdown/Dropdown';
 
-export class MonthlyScheduler extends React.Component<IInnerSchedulerProps, any> {
+export class MonthlyScheduler extends React.Component<IInnerSchedulerProps, {}> {
 
     render() {
         let {
@@ -46,31 +46,14 @@ export class MonthlyScheduler extends React.Component<IInnerSchedulerProps, any>
                 <span>The</span>
                 <Dropdown
                     hasTitleBorder={true}
-                    options={[
-                        { key: WeeksOfMonthEnum.First, text: 'First' },
-                        { key: WeeksOfMonthEnum.Second, text: 'Second' },
-                        { key: WeeksOfMonthEnum.Third, text: 'Third' },
-                        { key: WeeksOfMonthEnum.Fourth, text: 'Fourth' },
-                        { key: WeeksOfMonthEnum.Last, text: 'Last' }
-                    ]}
+                    options={this.weekOfMonthDropdownOptions}
                     onChanged={this.onWeeksOfMonthChanged}
                     selectedKey={weeksOfMonth}
                     dropdownType={DropdownType.selectionDropdown}
                 />
                 <Dropdown
                     hasTitleBorder={true}
-                    options={[
-                        { key: DaysOfWeekEnum.EveryDay, text: 'Day' },
-                        { key: DaysOfWeekEnum.WorkDays, text: 'Weekday' },
-                        { key: DaysOfWeekEnum.WeekendDays, text: 'Weekend day' },
-                        { key: DaysOfWeekEnum.Sunday, text: 'Sunday' },
-                        { key: DaysOfWeekEnum.Monday, text: 'Monday' },
-                        { key: DaysOfWeekEnum.Tuesday, text: 'Tuesday' },
-                        { key: DaysOfWeekEnum.Wednesday, text: 'Wednesday' },
-                        { key: DaysOfWeekEnum.Thursday, text: 'Thursday' },
-                        { key: DaysOfWeekEnum.Friday, text: 'Friday' },
-                        { key: DaysOfWeekEnum.Saturday, text: 'Saturday' }
-                    ]}
+                    options={this.dayOfWeekDropdownOptions}
                     onChanged={this.onSelectedDayOfWeekChanged}
                     selectedKey={daysOfWeek}
                     dropdownType={DropdownType.selectionDropdown}
@@ -95,13 +78,13 @@ export class MonthlyScheduler extends React.Component<IInnerSchedulerProps, any>
                             key: MonthlySheduleOptionEnum.OnDayOfMonth,
                             text: 'On specific day of month',
                             checked: sendOnSpecificDays,
-                            contentBelow: dayOfMonthChoiceText
+                            additionalContent: dayOfMonthChoiceText
                         },
                         {
                             key: MonthlySheduleOptionEnum.OnDayOfWeek,
                             text: 'On specific day of week',
                             checked: sendOnSpecificWeekDays,
-                            contentBelow: dayOfWeekChoiceText
+                            additionalContent: dayOfWeekChoiceText
                         }
                     ]}
                     onChanged={this.onChoiceGroupOptionChanged}
@@ -160,6 +143,27 @@ export class MonthlyScheduler extends React.Component<IInnerSchedulerProps, any>
         };
         this.props.onScheduleChanged(newSchedule);
     }
+
+    private dayOfWeekDropdownOptions = [
+        { key: DaysOfWeekEnum.EveryDay, text: 'Day' },
+        { key: DaysOfWeekEnum.WorkDays, text: 'Weekday' },
+        { key: DaysOfWeekEnum.WeekendDays, text: 'Weekend day' },
+        { key: DaysOfWeekEnum.Sunday, text: 'Sunday' },
+        { key: DaysOfWeekEnum.Monday, text: 'Monday' },
+        { key: DaysOfWeekEnum.Tuesday, text: 'Tuesday' },
+        { key: DaysOfWeekEnum.Wednesday, text: 'Wednesday' },
+        { key: DaysOfWeekEnum.Thursday, text: 'Thursday' },
+        { key: DaysOfWeekEnum.Friday, text: 'Friday' },
+        { key: DaysOfWeekEnum.Saturday, text: 'Saturday' }
+    ];
+
+    private weekOfMonthDropdownOptions = [
+        { key: WeeksOfMonthEnum.First, text: 'First' },
+        { key: WeeksOfMonthEnum.Second, text: 'Second' },
+        { key: WeeksOfMonthEnum.Third, text: 'Third' },
+        { key: WeeksOfMonthEnum.Fourth, text: 'Fourth' },
+        { key: WeeksOfMonthEnum.Last, text: 'Last' }
+    ];
 
     private dayOfMonthDropdownOptions = [
         { key: DayOfMonthEnum.Day1, text: '1' },

--- a/src/components/Scheduler/InnerSchedulers/MonthlyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/MonthlyScheduler.tsx
@@ -1,31 +1,200 @@
+/* tslint:disable:no-bitwise */
 import * as React from 'react';
 import * as NumericInput from 'react-numeric-input';
 import { IInnerSchedulerProps } from './InnerScheduler.Props';
 import { TextField } from '../../TextField/TextField';
-import { MonthlySchedule } from '../Scheduler.Props';
+import { MonthlySchedule, DaysOfWeekEnum, WeeksOfMonthEnum, DayOfMonthEnum } from '../Scheduler.Props';
+import { ChoiceGroup } from '../../ChoiceGroup/ChoiceGroup';
+import { DropdownType } from '../../Dropdown/Dropdown.Props';
+import { Dropdown } from '../../Dropdown/Dropdown';
 
 export class MonthlyScheduler extends React.PureComponent<IInnerSchedulerProps, any> {
 
     render() {
-        let { recurrencePeriod } = this.props.schedule as MonthlySchedule;
+        let {
+            sendOnSpecificDays,
+            daysOfMonth,
+            sendOnSpecificWeekDays,
+            weeksOfMonth,
+            daysOfWeek,
+            recurrencePeriod
+        } = this.props.schedule as MonthlySchedule;
+
+        const dayOfMonthChoiceText: any = (
+            <div className="choice-item-text">
+                <span>Day</span>
+                <Dropdown
+                    hasTitleBorder={true}
+                    options={this.dayOfMonthDropdownOptions}
+                    onChanged={this.onDayOfMonthChanged}
+                    selectedKey={daysOfMonth}
+                    dropdownType={DropdownType.selectionDropdown}
+                />
+                <span>of every</span>
+                <TextField
+                    type="number"
+                    min="1"
+                    value={recurrencePeriod.toString()}
+                    onChanged={this.onMonthRecurrencePeriodChanged}
+                />
+                <span>month(s)</span>
+            </div>
+        );
+
+        const dayOfWeekChoiceText: any = (
+            <div className="choice-item-text">
+                <span>The</span>
+                <Dropdown
+                    hasTitleBorder={true}
+                    options={[
+                        { key: WeeksOfMonthEnum.First, text: 'First' },
+                        { key: WeeksOfMonthEnum.Second, text: 'Second' },
+                        { key: WeeksOfMonthEnum.Third, text: 'Third' },
+                        { key: WeeksOfMonthEnum.Fourth, text: 'Fourth' },
+                        { key: WeeksOfMonthEnum.Last, text: 'Last' }
+                    ]}
+                    onChanged={this.onWeeksOfMonthChanged}
+                    selectedKey={weeksOfMonth}
+                    dropdownType={DropdownType.selectionDropdown}
+                />
+                <Dropdown
+                    hasTitleBorder={true}
+                    options={[
+                        { key: DaysOfWeekEnum.EveryDay, text: 'Day' },
+                        { key: DaysOfWeekEnum.WorkDays, text: 'Weekday' },
+                        { key: DaysOfWeekEnum.WeekendDays, text: 'Weekend day' },
+                        { key: DaysOfWeekEnum.Sunday, text: 'Sunday' },
+                        { key: DaysOfWeekEnum.Monday, text: 'Monday' },
+                        { key: DaysOfWeekEnum.Tuesday, text: 'Tuesday' },
+                        { key: DaysOfWeekEnum.Wednesday, text: 'Wednesday' },
+                        { key: DaysOfWeekEnum.Thursday, text: 'Thursday' },
+                        { key: DaysOfWeekEnum.Friday, text: 'Friday' },
+                        { key: DaysOfWeekEnum.Saturday, text: 'Saturday' }
+                    ]}
+                    onChanged={this.onSelectedDayOfWeekChanged}
+                    selectedKey={daysOfWeek}
+                    dropdownType={DropdownType.selectionDropdown}
+                />
+                <span>of every</span>
+                <TextField
+                    type="number"
+                    min="1"
+                    value={recurrencePeriod.toString()}
+                    onChanged={this.onMonthRecurrencePeriodChanged}
+                />
+                <span>months(s)</span>
+            </div>
+        );
+
 
         return (
-            <div>
-                <NumericInput
-                    value={recurrencePeriod}
-                    onChange={this.onRecurrencePeriodChanged}
+            <div className="monthly-scheduler">
+                <ChoiceGroup
+                    options={[
+                        {
+                            key: MonthlySheduleOptionEnum.OnDayOfMonth,
+                            text: dayOfMonthChoiceText,
+                            checked: sendOnSpecificDays
+                        },
+                        {
+                            key: MonthlySheduleOptionEnum.OnDayOfWeek,
+                            text: dayOfWeekChoiceText,
+                            checked: sendOnSpecificWeekDays
+                        }
+                    ]}
+                    onChanged={this.onChoiceGroupOptionChanged}
                 />
             </div>
         );
     }
 
-    onRecurrencePeriodChanged = (value) => {
+    onDayOfMonthChanged = (option, index) => {
+        const newSchedule = {
+            ...this.props.schedule,
+            daysOfMonth: option.key
+        };
+        this.props.onScheduleChanged(newSchedule);
+    }
+
+    onMonthRecurrencePeriodChanged = (input) => {
+        const value = parseInt(input, 10);
         let newSchedule = {
             ...this.props.schedule,
             recurrencePeriod: value
         };
         this.props.onScheduleChanged(newSchedule);
     }
+
+    onChoiceGroupOptionChanged = (value) => {
+        let sendOnSpecificDays: boolean;
+        let sendOnSpecificWeekDays: boolean;
+        if (value.key === MonthlySheduleOptionEnum.OnDayOfMonth.toString()) {
+            sendOnSpecificDays = true;
+            sendOnSpecificWeekDays = false;
+        } else {
+            sendOnSpecificDays = false;
+            sendOnSpecificWeekDays = true;
+        }
+        const newSchedule = {
+            ...this.props.schedule,
+            sendOnSpecificDays: sendOnSpecificDays,
+            sendOnSpecificWeekDays: sendOnSpecificWeekDays
+        };
+        this.props.onScheduleChanged(newSchedule);
+    }
+
+    onWeeksOfMonthChanged = (option, index) => {
+        const newSchedule = {
+            ...this.props.schedule,
+            weeksOfMonth: option.key
+        };
+        this.props.onScheduleChanged(newSchedule);
+    }
+
+    onSelectedDayOfWeekChanged = (option, index) => {
+        const newSchedule = {
+            ...this.props.schedule,
+            daysOfWeek: option.key
+        };
+        this.props.onScheduleChanged(newSchedule);
+    }
+
+    private dayOfMonthDropdownOptions = [
+        { key: DayOfMonthEnum.Day1, text: '1' },
+        { key: DayOfMonthEnum.Day2, text: '2' },
+        { key: DayOfMonthEnum.Day3, text: '3' },
+        { key: DayOfMonthEnum.Day4, text: '4' },
+        { key: DayOfMonthEnum.Day5, text: '5' },
+        { key: DayOfMonthEnum.Day6, text: '6' },
+        { key: DayOfMonthEnum.Day7, text: '7' },
+        { key: DayOfMonthEnum.Day8, text: '8' },
+        { key: DayOfMonthEnum.Day8, text: '9' },
+        { key: DayOfMonthEnum.Day10, text: '10' },
+        { key: DayOfMonthEnum.Day11, text: '11' },
+        { key: DayOfMonthEnum.Day12, text: '12' },
+        { key: DayOfMonthEnum.Day13, text: '13' },
+        { key: DayOfMonthEnum.Day14, text: '14' },
+        { key: DayOfMonthEnum.Day15, text: '15' },
+        { key: DayOfMonthEnum.Day16, text: '16' },
+        { key: DayOfMonthEnum.Day17, text: '17' },
+        { key: DayOfMonthEnum.Day18, text: '18' },
+        { key: DayOfMonthEnum.Day19, text: '19' },
+        { key: DayOfMonthEnum.Day20, text: '20' },
+        { key: DayOfMonthEnum.Day21, text: '21' },
+        { key: DayOfMonthEnum.Day22, text: '22' },
+        { key: DayOfMonthEnum.Day23, text: '23' },
+        { key: DayOfMonthEnum.Day24, text: '24' },
+        { key: DayOfMonthEnum.Day25, text: '25' },
+        { key: DayOfMonthEnum.Day26, text: '26' },
+        { key: DayOfMonthEnum.Day27, text: '27' },
+        { key: DayOfMonthEnum.Day28, text: '28' },
+        { key: DayOfMonthEnum.Day29, text: '29' },
+        { key: DayOfMonthEnum.Day30, text: '30' },
+        { key: DayOfMonthEnum.Day31, text: '31' }
+    ];
 }
 
-
+export enum MonthlySheduleOptionEnum {
+    OnDayOfMonth = '1',
+    OnDayOfWeek = '2'
+}

--- a/src/components/Scheduler/InnerSchedulers/WeeklyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/WeeklyScheduler.tsx
@@ -6,7 +6,7 @@ import { TextField } from '../../TextField/TextField';
 import { CheckboxList } from '../../CheckboxList/CheckboxList';
 import { DaysOfWeekEnum } from '../../../index';
 
-export class WeeklyScheduler extends React.Component<IInnerSchedulerProps, any> {
+export class WeeklyScheduler extends React.Component<IInnerSchedulerProps, {}> {
 
     render() {
         let { recurrencePeriod, daysOfWeek } = this.props.schedule;

--- a/src/components/Scheduler/InnerSchedulers/WeeklyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/WeeklyScheduler.tsx
@@ -25,15 +25,7 @@ export class WeeklyScheduler extends React.Component<IInnerSchedulerProps, any> 
                 </div>
                 <CheckboxList
                     onCheckboxChanged={this.onCheckboxListChange}
-                    items={[
-                        { id: DaysOfWeekEnum.Sunday.toString(), text: 'Sunday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Sunday) },
-                        { id: DaysOfWeekEnum.Monday.toString(), text: 'Monday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Monday) },
-                        { id: DaysOfWeekEnum.Tuesday.toString(), text: 'Tuesday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Tuesday) },
-                        { id: DaysOfWeekEnum.Wednesday.toString(), text: 'Wednesday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Wednesday) },
-                        { id: DaysOfWeekEnum.Thursday.toString(), text: 'Thursday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Thursday) },
-                        { id: DaysOfWeekEnum.Friday.toString(), text: 'Friday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Friday) },
-                        { id: DaysOfWeekEnum.Saturday.toString(), text: 'Saturday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Saturday) }
-                    ]}
+                    items={this.getWeeklyCheckboxListItems(daysOfWeek)}
                 />
             </div>
         );
@@ -61,5 +53,45 @@ export class WeeklyScheduler extends React.Component<IInnerSchedulerProps, any> 
             daysOfWeek: newDaysOfWeek
         };
         this.props.onScheduleChanged(newSchedule);
+    }
+
+    getWeeklyCheckboxListItems = (daysOfWeek) => {
+        return [
+            {
+                id: DaysOfWeekEnum.Sunday.toString(),
+                text: 'Sunday',
+                checked: Boolean(daysOfWeek & DaysOfWeekEnum.Sunday)
+            },
+            {
+                id: DaysOfWeekEnum.Monday.toString(),
+                text: 'Monday',
+                checked: Boolean(daysOfWeek & DaysOfWeekEnum.Monday)
+            },
+            {
+                id: DaysOfWeekEnum.Tuesday.toString(),
+                text: 'Tuesday',
+                checked: Boolean(daysOfWeek & DaysOfWeekEnum.Tuesday)
+            },
+            {
+                id: DaysOfWeekEnum.Wednesday.toString(),
+                text: 'Wednesday',
+                checked: Boolean(daysOfWeek & DaysOfWeekEnum.Wednesday)
+            },
+            {
+                id: DaysOfWeekEnum.Thursday.toString(),
+                text: 'Thursday',
+                checked: Boolean(daysOfWeek & DaysOfWeekEnum.Thursday)
+            },
+            {
+                id: DaysOfWeekEnum.Friday.toString(),
+                text: 'Friday',
+                checked: Boolean(daysOfWeek & DaysOfWeekEnum.Friday)
+            },
+            {
+                id: DaysOfWeekEnum.Saturday.toString(),
+                text: 'Saturday',
+                checked: Boolean(daysOfWeek & DaysOfWeekEnum.Saturday)
+            }
+        ];
     }
 }

--- a/src/components/Scheduler/InnerSchedulers/WeeklyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/WeeklyScheduler.tsx
@@ -14,18 +14,20 @@ export class WeeklyScheduler extends React.PureComponent<IInnerSchedulerProps, a
 
         return (
             <div className="weekly-scheduler">
-                <TextField
-                    type="number"
-                    min="1"
-                    value={recurrencePeriod.toString()}
-                    onChanged={this.onRecurrencePeriodChanged}
-                    label="Recurrence period: "
-                    
-                />
+                <div className="textField-container">
+                    <span> Recur every </span>
+                    <TextField
+                        type="number"
+                        min="1"
+                        value={recurrencePeriod.toString()}
+                        onChanged={this.onRecurrencePeriodChanged}
+                    />
+                    <span> minutes on: </span>
+                </div>
                 <CheckboxList
                     onCheckboxChanged={this.onCheckboxListChange}
                     items={[
-                        { id: DaysOfWeekEnum.Sunday.toString(), text: 'Sunday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Sunday)},
+                        { id: DaysOfWeekEnum.Sunday.toString(), text: 'Sunday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Sunday) },
                         { id: DaysOfWeekEnum.Monday.toString(), text: 'Monday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Monday) },
                         { id: DaysOfWeekEnum.Tuesday.toString(), text: 'Tuesday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Tuesday) },
                         { id: DaysOfWeekEnum.Wednesday.toString(), text: 'Wednesday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Wednesday) },

--- a/src/components/Scheduler/InnerSchedulers/WeeklyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/WeeklyScheduler.tsx
@@ -13,14 +13,16 @@ export class WeeklyScheduler extends React.PureComponent<IInnerSchedulerProps, a
         let { recurrencePeriod, daysOfWeek } = this.props.schedule as WeeklySchedule;
 
         return (
-            <div>
+            <div className="weekly-scheduler">
                 <TextField
                     type="number"
+                    min="1"
                     value={recurrencePeriod.toString()}
-                    onChange={this.onRecurrencePeriodChanged}
+                    onChanged={this.onRecurrencePeriodChanged}
+                    label="Recurrence period: "
+                    
                 />
                 <CheckboxList
-                    title={'Checkbox List'}
                     onCheckboxChanged={this.onCheckboxListChange}
                     items={[
                         { id: DaysOfWeekEnum.Sunday.toString(), text: 'Sunday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Sunday)},
@@ -36,8 +38,8 @@ export class WeeklyScheduler extends React.PureComponent<IInnerSchedulerProps, a
         );
     }
 
-    onRecurrencePeriodChanged = (e) => {
-        const value = parseInt(e.target.value, 10);
+    onRecurrencePeriodChanged = (input) => {
+        const value = parseInt(input, 10);
         const newSchedule = {
             ...this.props.schedule,
             recurrencePeriod: value
@@ -45,10 +47,10 @@ export class WeeklyScheduler extends React.PureComponent<IInnerSchedulerProps, a
         this.props.onScheduleChanged(newSchedule);
     }
 
-    onCheckboxListChange = (e, index: string, checked) => {
+    onCheckboxListChange = (e, index: string, checked: boolean) => {
         const schedule = this.props.schedule as WeeklySchedule;
-        const flipday = parseInt(index, 10);
-        const newDaysOfWeek = schedule.daysOfWeek ^ flipday;
+        const dayToFlip = parseInt(index, 10);
+        const newDaysOfWeek = schedule.daysOfWeek ^ dayToFlip;
         const newSchedule = {
             ...this.props.schedule,
             daysOfWeek: newDaysOfWeek
@@ -56,4 +58,3 @@ export class WeeklyScheduler extends React.PureComponent<IInnerSchedulerProps, a
         this.props.onScheduleChanged(newSchedule);
     }
 }
-

--- a/src/components/Scheduler/InnerSchedulers/WeeklyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/WeeklyScheduler.tsx
@@ -3,17 +3,16 @@ import * as React from 'react';
 import * as NumericInput from 'react-numeric-input';
 import { IInnerSchedulerProps } from './InnerScheduler.Props';
 import { TextField } from '../../TextField/TextField';
-import { WeeklySchedule } from '../Scheduler.Props';
 import { CheckboxList } from '../../CheckboxList/CheckboxList';
 import { DaysOfWeekEnum } from '../../../index';
 
-export class WeeklyScheduler extends React.PureComponent<IInnerSchedulerProps, any> {
+export class WeeklyScheduler extends React.Component<IInnerSchedulerProps, any> {
 
     render() {
-        let { recurrencePeriod, daysOfWeek } = this.props.schedule as WeeklySchedule;
+        let { recurrencePeriod, daysOfWeek } = this.props.schedule;
 
         return (
-            <div className="weekly-scheduler">
+            <div className="weekly-scheduler inner-scheduler">
                 <div className="textField-container">
                     <span> Recur every </span>
                     <TextField
@@ -42,6 +41,10 @@ export class WeeklyScheduler extends React.PureComponent<IInnerSchedulerProps, a
 
     onRecurrencePeriodChanged = (input) => {
         const value = parseInt(input, 10);
+        if (value === this.props.schedule.recurrencePeriod) {
+            return;
+        }
+
         const newSchedule = {
             ...this.props.schedule,
             recurrencePeriod: value
@@ -50,7 +53,7 @@ export class WeeklyScheduler extends React.PureComponent<IInnerSchedulerProps, a
     }
 
     onCheckboxListChange = (e, index: string, checked: boolean) => {
-        const schedule = this.props.schedule as WeeklySchedule;
+        const schedule = this.props.schedule;
         const dayToFlip = parseInt(index, 10);
         const newDaysOfWeek = schedule.daysOfWeek ^ dayToFlip;
         const newSchedule = {

--- a/src/components/Scheduler/InnerSchedulers/WeeklyScheduler.tsx
+++ b/src/components/Scheduler/InnerSchedulers/WeeklyScheduler.tsx
@@ -1,0 +1,59 @@
+/* tslint:disable:no-bitwise */
+import * as React from 'react';
+import * as NumericInput from 'react-numeric-input';
+import { IInnerSchedulerProps } from './InnerScheduler.Props';
+import { TextField } from '../../TextField/TextField';
+import { WeeklySchedule } from '../Scheduler.Props';
+import { CheckboxList } from '../../CheckboxList/CheckboxList';
+import { DaysOfWeekEnum } from '../../../index';
+
+export class WeeklyScheduler extends React.PureComponent<IInnerSchedulerProps, any> {
+
+    render() {
+        let { recurrencePeriod, daysOfWeek } = this.props.schedule as WeeklySchedule;
+
+        return (
+            <div>
+                <TextField
+                    type="number"
+                    value={recurrencePeriod.toString()}
+                    onChange={this.onRecurrencePeriodChanged}
+                />
+                <CheckboxList
+                    title={'Checkbox List'}
+                    onCheckboxChanged={this.onCheckboxListChange}
+                    items={[
+                        { id: DaysOfWeekEnum.Sunday.toString(), text: 'Sunday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Sunday)},
+                        { id: DaysOfWeekEnum.Monday.toString(), text: 'Monday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Monday) },
+                        { id: DaysOfWeekEnum.Tuesday.toString(), text: 'Tuesday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Tuesday) },
+                        { id: DaysOfWeekEnum.Wednesday.toString(), text: 'Wednesday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Wednesday) },
+                        { id: DaysOfWeekEnum.Thursday.toString(), text: 'Thursday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Thursday) },
+                        { id: DaysOfWeekEnum.Friday.toString(), text: 'Friday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Friday) },
+                        { id: DaysOfWeekEnum.Saturday.toString(), text: 'Saturday', checked: Boolean(daysOfWeek & DaysOfWeekEnum.Saturday) }
+                    ]}
+                />
+            </div>
+        );
+    }
+
+    onRecurrencePeriodChanged = (e) => {
+        const value = parseInt(e.target.value, 10);
+        const newSchedule = {
+            ...this.props.schedule,
+            recurrencePeriod: value
+        };
+        this.props.onScheduleChanged(newSchedule);
+    }
+
+    onCheckboxListChange = (e, index: string, checked) => {
+        const schedule = this.props.schedule as WeeklySchedule;
+        const flipday = parseInt(index, 10);
+        const newDaysOfWeek = schedule.daysOfWeek ^ flipday;
+        const newSchedule = {
+            ...this.props.schedule,
+            daysOfWeek: newDaysOfWeek
+        };
+        this.props.onScheduleChanged(newSchedule);
+    }
+}
+

--- a/src/components/Scheduler/Scheduler.Props.ts
+++ b/src/components/Scheduler/Scheduler.Props.ts
@@ -1,0 +1,114 @@
+import { IDropdownOption } from '../Dropdown/Dropdown.Props';
+
+export interface ISchedulerProps {
+    selectedScheduleType: ScheduleTypeEnum;
+    schedule: Schedule;
+    className?: string;
+    scheduleTypeChanged: (option: IDropdownOption, index?: number) => void;
+    onScheduleChanged: (schedule: Schedule) => void;
+    dropdownOptions?: IDropdownOption[];
+    dropdownLabel?: string;
+}
+
+export interface Schedule {
+    startTime: Date;
+}
+
+export interface OneTimeSchedule extends Schedule {
+
+}
+
+export interface MinutelySchedule extends Schedule {
+    recurrencePeriod: number;
+}
+
+export interface HourlySchedule extends Schedule {
+    recurrencePeriod: number;
+}
+
+export interface DailySchedule extends Schedule {
+    recurrencePeriod: number;
+    daysOfWeek: DaysOfWeekEnum;
+}
+
+export interface WeeklySchedule extends Schedule {
+    recurrencePeriod: number;
+    daysOfWeek: DaysOfWeekEnum;
+}
+
+export interface MonthlySchedule extends Schedule {
+    sendOnSpecificDays: boolean;
+    daysOfMonth: DayOfMonthEnum; 
+    sendOnSpecificWeekDays: boolean; 
+    weeksOfMonth: WeeksOfMonthEnum;
+    daysOfWeek: DaysOfWeekEnum;
+    recurrencePeriod: number;
+}
+
+export enum DaysOfWeekEnum {
+    Sunday = 1,
+    Monday = 2,
+    Tuesday = 4,
+    Wednesday = 8,
+    Thursday = 16,
+    Friday = 32,
+    WorkDays = 62,
+    Saturday = 64,
+    WeekendDays = 65,
+    EveryDay = 127
+}
+
+export enum DayOfMonthEnum {
+    Day1 = 1,
+    Day2 = 2,
+    Day3 = 4,
+    Day4 = 8,
+    Day5 = 16,
+    Day6 = 32,
+    Day7 = 64,
+    Day8 = 128,
+    Day9 = 256,
+    Day10 = 512,
+    Day11 = 1024,
+    Day12 = 2048,
+    Day13 = 4096,
+    Day14 = 8192,
+    Day15 = 16384,
+    Day16 = 32768,
+    Day17 = 65536,
+    Day18 = 131072,
+    Day19 = 262144,
+    Day20 = 524288,
+    Day21 = 1048576,
+    Day22 = 2097152,
+    Day23 = 4194304,
+    Day24 = 8388608,
+    Day25 = 16777216,
+    Day26 = 33554432,
+    Day27 = 67108864,
+    Day28 = 134217728,
+    Day29 = 268435456,
+    Day30 = 536870912,
+    Day31 = 1073741824,
+    Everyday = 2147483647,
+    Last = 4294967294
+}
+
+export enum WeeksOfMonthEnum {
+    None = 0,
+    First = 1,
+    Second = 2,
+    Third = 3,
+    Fourth = 4,
+    Last = 5
+}
+
+export enum ScheduleTypeEnum {
+    OneTime = 1,
+    Daily = 2,
+    Weekly = 3,
+    Monthly = 4,
+    Quarterly = 5,
+    Minutely = 6,
+    Hourly = 7
+}

--- a/src/components/Scheduler/Scheduler.Props.ts
+++ b/src/components/Scheduler/Scheduler.Props.ts
@@ -12,31 +12,6 @@ export interface ISchedulerProps {
 
 export interface Schedule {
     startTime: Date;
-}
-
-export interface OneTimeSchedule extends Schedule {
-
-}
-
-export interface MinutelySchedule extends Schedule {
-    recurrencePeriod: number;
-}
-
-export interface HourlySchedule extends Schedule {
-    recurrencePeriod: number;
-}
-
-export interface DailySchedule extends Schedule {
-    recurrencePeriod: number;
-    daysOfWeek: DaysOfWeekEnum;
-}
-
-export interface WeeklySchedule extends Schedule {
-    recurrencePeriod: number;
-    daysOfWeek: DaysOfWeekEnum;
-}
-
-export interface MonthlySchedule extends Schedule {
     sendOnSpecificDays: boolean;
     daysOfMonth: DayOfMonthEnum; 
     sendOnSpecificWeekDays: boolean; 

--- a/src/components/Scheduler/Scheduler.scss
+++ b/src/components/Scheduler/Scheduler.scss
@@ -1,20 +1,37 @@
 .scheduler {
-    label.choiceField-field {
-        padding-bottom: 10px;
+
+    div.dropdown-container, div.textField-container {
+        display: flex;
+        align-items: center;
+        margin: 10px 0px;
+
+        > span {
+            margin-right: 10px;
+        }
+    }
+
+    .dropdown {
+        margin: 0px 10px 0px 0px;
+    }
+    
+    .text-field{
+        margin-bottom: 0px;
+        width: 70px;
+        margin-right: 10px;
+
+        > .textField-field {
+            width: 100%;
+        }
     }
 
     .choiceFieldGroup {
+        margin-left: 10px;
         .choice-item-text {
             display: flex;
             align-items: center;
 
-            .dropdown {
-                margin-bottom: 0px;
-            }
-
-            > div, span {
-                padding-right: 10px;
-                margin-bottom: 0px;
+            > span {
+                margin-right: 10px;
             }
         }
     }  
@@ -22,7 +39,7 @@
     > .weekly-scheduler {
         .checkboxlist {
             display: flex;
-
+            margin-left: 5px;
             > div {
                 padding-right: 10px;
             }

--- a/src/components/Scheduler/Scheduler.scss
+++ b/src/components/Scheduler/Scheduler.scss
@@ -1,0 +1,31 @@
+.scheduler {
+    label.choiceField-field {
+        padding-bottom: 10px;
+    }
+
+    .choiceFieldGroup {
+        .choice-item-text {
+            display: flex;
+            align-items: center;
+
+            .dropdown {
+                margin-bottom: 0px;
+            }
+
+            > div, span {
+                padding-right: 10px;
+                margin-bottom: 0px;
+            }
+        }
+    }  
+
+    > .weekly-scheduler {
+        .checkboxlist {
+            display: flex;
+
+            > div {
+                padding-right: 10px;
+            }
+        }
+    }
+}

--- a/src/components/Scheduler/Scheduler.scss
+++ b/src/components/Scheduler/Scheduler.scss
@@ -36,16 +36,22 @@
                     margin-right: 10px;
                 }
             }
-        }  
+        }
 
         &.weekly-scheduler {
             .checkboxlist {
                 display: flex;
-                margin-left: 5px;
+                margin-left: 10px;
                 > div {
-                    padding-right: 10px;
+                    padding-right: 15px;
                 }
             }
         }
+    }
+}
+
+.scheduler-day-of-month-dropdown-callout {
+    .callout-main {
+        max-height: 200px !important;
     }
 }

--- a/src/components/Scheduler/Scheduler.scss
+++ b/src/components/Scheduler/Scheduler.scss
@@ -3,7 +3,7 @@
     div.dropdown-container, div.textField-container {
         display: flex;
         align-items: center;
-        margin: 10px 0px;
+        margin: 15px 0px;
 
         > span {
             margin-right: 10px;
@@ -24,24 +24,27 @@
         }
     }
 
-    .choiceFieldGroup {
-        margin-left: 10px;
-        .choice-item-text {
-            display: flex;
-            align-items: center;
+    > .inner-scheduler {
+        margin: 10px;
 
-            > span {
-                margin-right: 10px;
+        .choiceFieldGroup {
+            .choice-item-content {
+                display: flex;
+                align-items: center;
+
+                > span {
+                    margin-right: 10px;
+                }
             }
-        }
-    }  
+        }  
 
-    > .weekly-scheduler {
-        .checkboxlist {
-            display: flex;
-            margin-left: 5px;
-            > div {
-                padding-right: 10px;
+        &.weekly-scheduler {
+            .checkboxlist {
+                display: flex;
+                margin-left: 5px;
+                > div {
+                    padding-right: 10px;
+                }
             }
         }
     }

--- a/src/components/Scheduler/Scheduler.tsx
+++ b/src/components/Scheduler/Scheduler.tsx
@@ -79,22 +79,25 @@ export class Scheduler extends React.PureComponent<ISchedulerProps, any> {
 
         return (
             <div className={classNames('scheduler', className)}>
-                <Dropdown
-                    hasTitleBorder={true}
-                    options={dropdownOptions}
-                    onChanged={scheduleTypeChanged}
-                    label={dropdownLabel}
-                    selectedKey={selectedScheduleType}
-                    dropdownType={DropdownType.selectionDropdown}
-
-                />
-                <div>Start time:</div>
-                <DateTimeDropdownPicker
-                    selectedDate={schedule.startTime}
-                    onTimeSelectionChanged={this.startDateTimeChanged}
-                    className="date-time-picker-dropdown"
-                    includeTime={true}
-                />
+                <div className="dropdown-container">
+                    <span>{dropdownLabel}</span>
+                    <Dropdown
+                        hasTitleBorder={true}
+                        options={dropdownOptions}
+                        onChanged={scheduleTypeChanged}
+                        selectedKey={selectedScheduleType}
+                        dropdownType={DropdownType.selectionDropdown}
+                    />
+                </div>
+                <div className="dropdown-container">
+                    <span>Start time:</span>
+                    <DateTimeDropdownPicker
+                        selectedDate={schedule.startTime}
+                        onTimeSelectionChanged={this.startDateTimeChanged}
+                        className="date-time-picker-dropdown"
+                        includeTime={true}
+                    />
+                </div>
                 {component}
             </div>
         );

--- a/src/components/Scheduler/Scheduler.tsx
+++ b/src/components/Scheduler/Scheduler.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import { ISchedulerProps, ScheduleTypeEnum } from './Scheduler.Props';
+import { Dropdown } from '../Dropdown/Dropdown';
+import { DateTimeDropdownPicker } from '../DateTimeDropdownPicker/DateTimeDropdownPicker';
+import { HourlyScheduler } from './InnerSchedulers/HourlyScheduler';
+import * as classNames from 'classnames';
+
+export class Scheduler extends React.PureComponent<ISchedulerProps, any> {
+    public static defaultProps = {
+        dropdownOptions: [
+            { key: ScheduleTypeEnum.OneTime, text: 'One time' },
+            { key: ScheduleTypeEnum.Minutely, text: 'On the minute' },
+            { key: ScheduleTypeEnum.Hourly, text: 'Hourly' },
+            { key: ScheduleTypeEnum.Daily, text: 'Daily' },
+            { key: ScheduleTypeEnum.Weekly, text: 'Weekly' },
+            { key: ScheduleTypeEnum.Monthly, text: 'Monthly' }
+        ],
+        dropdownLabel: 'Recurrence Type:'
+    };
+
+    render() {
+        let { dropdownOptions,
+            schedule,
+            selectedScheduleType,
+            scheduleTypeChanged,
+            dropdownLabel,
+            className,
+            onScheduleChanged } = this.props;
+
+        let component;
+        switch (selectedScheduleType) {
+            case ScheduleTypeEnum.OneTime:
+                component = null;
+                break;
+            case ScheduleTypeEnum.Hourly:
+                component = (
+                    <HourlyScheduler
+                        schedule={schedule}
+                        onScheduleChanged={onScheduleChanged}
+                        {...schedule} />);
+                break;
+                case ScheduleTypeEnum.Minutely:
+                component = (
+                    <HourlyScheduler
+                        schedule={schedule}
+                        onScheduleChanged={onScheduleChanged}
+                        {...schedule} />);
+                break;
+            default:
+                component = null;
+        }
+
+        return (
+            <div className={classNames('scheduler', className)}>
+                <Dropdown
+                    options={dropdownOptions}
+                    onChanged={scheduleTypeChanged}
+                    label={dropdownLabel}
+                    selectedKey={selectedScheduleType}
+
+                />
+                <div>Start time:</div>
+                <DateTimeDropdownPicker
+                    selectedDate={schedule.startTime}
+                    onTimeSelectionChanged={this.startDateTimeChanged}
+                    className="date-time-picker-dropdown"
+                />
+                {component}
+            </div>
+        );
+    }
+
+    startDateTimeChanged = (date: Date) => {
+        let newSchedule = {
+            ...this.props.schedule,
+            startTime: date
+        };
+        this.props.onScheduleChanged(newSchedule);
+    }
+}
+

--- a/src/components/Scheduler/Scheduler.tsx
+++ b/src/components/Scheduler/Scheduler.tsx
@@ -4,6 +4,10 @@ import { Dropdown } from '../Dropdown/Dropdown';
 import { DateTimeDropdownPicker } from '../DateTimeDropdownPicker/DateTimeDropdownPicker';
 import { HourlyScheduler } from './InnerSchedulers/HourlyScheduler';
 import * as classNames from 'classnames';
+import { DropdownType } from '../Dropdown/Dropdown.Props';
+import { DailyScheduler } from './InnerSchedulers/DailyScheduler';
+import { WeeklyScheduler } from './InnerSchedulers/WeeklyScheduler';
+import { MonthlyScheduler } from './InnerSchedulers/MonthlyScheduler';
 
 export class Scheduler extends React.PureComponent<ISchedulerProps, any> {
     public static defaultProps = {
@@ -32,6 +36,13 @@ export class Scheduler extends React.PureComponent<ISchedulerProps, any> {
             case ScheduleTypeEnum.OneTime:
                 component = null;
                 break;
+            case ScheduleTypeEnum.Minutely:
+                component = (
+                    <HourlyScheduler
+                        schedule={schedule}
+                        onScheduleChanged={onScheduleChanged}
+                        {...schedule} />);
+                break;
             case ScheduleTypeEnum.Hourly:
                 component = (
                     <HourlyScheduler
@@ -39,9 +50,23 @@ export class Scheduler extends React.PureComponent<ISchedulerProps, any> {
                         onScheduleChanged={onScheduleChanged}
                         {...schedule} />);
                 break;
-                case ScheduleTypeEnum.Minutely:
+            case ScheduleTypeEnum.Daily:
                 component = (
-                    <HourlyScheduler
+                    <DailyScheduler
+                        schedule={schedule}
+                        onScheduleChanged={onScheduleChanged}
+                        {...schedule} />);
+                break;
+            case ScheduleTypeEnum.Weekly:
+                component = (
+                    <WeeklyScheduler
+                        schedule={schedule}
+                        onScheduleChanged={onScheduleChanged}
+                        {...schedule} />);
+                break;
+            case ScheduleTypeEnum.Monthly:
+                component = (
+                    <MonthlyScheduler
                         schedule={schedule}
                         onScheduleChanged={onScheduleChanged}
                         {...schedule} />);
@@ -57,6 +82,7 @@ export class Scheduler extends React.PureComponent<ISchedulerProps, any> {
                     onChanged={scheduleTypeChanged}
                     label={dropdownLabel}
                     selectedKey={selectedScheduleType}
+                    dropdownType={DropdownType.selectionDropdown}
 
                 />
                 <div>Start time:</div>
@@ -64,6 +90,7 @@ export class Scheduler extends React.PureComponent<ISchedulerProps, any> {
                     selectedDate={schedule.startTime}
                     onTimeSelectionChanged={this.startDateTimeChanged}
                     className="date-time-picker-dropdown"
+                    includeTime={true}
                 />
                 {component}
             </div>

--- a/src/components/Scheduler/Scheduler.tsx
+++ b/src/components/Scheduler/Scheduler.tsx
@@ -11,7 +11,7 @@ import { MonthlyScheduler } from './InnerSchedulers/MonthlyScheduler';
 import { MinutelyScheduler } from './InnerSchedulers/MinutelyScheduler';
 import './Scheduler.scss';
 
-export class Scheduler extends React.PureComponent<ISchedulerProps, any> {
+export class Scheduler extends React.Component<ISchedulerProps, any> {
     public static defaultProps = {
         dropdownOptions: [
             { key: ScheduleTypeEnum.OneTime, text: 'One time' },
@@ -32,50 +32,6 @@ export class Scheduler extends React.PureComponent<ISchedulerProps, any> {
             dropdownLabel,
             className,
             onScheduleChanged } = this.props;
-
-        let component;
-        switch (selectedScheduleType) {
-            case ScheduleTypeEnum.OneTime:
-                component = null;
-                break;
-            case ScheduleTypeEnum.Minutely:
-                component = (
-                    <MinutelyScheduler
-                        schedule={schedule}
-                        onScheduleChanged={onScheduleChanged}
-                        {...schedule} />);
-                break;
-            case ScheduleTypeEnum.Hourly:
-                component = (
-                    <HourlyScheduler
-                        schedule={schedule}
-                        onScheduleChanged={onScheduleChanged}
-                        {...schedule} />);
-                break;
-            case ScheduleTypeEnum.Daily:
-                component = (
-                    <DailyScheduler
-                        schedule={schedule}
-                        onScheduleChanged={onScheduleChanged}
-                        {...schedule} />);
-                break;
-            case ScheduleTypeEnum.Weekly:
-                component = (
-                    <WeeklyScheduler
-                        schedule={schedule}
-                        onScheduleChanged={onScheduleChanged}
-                        {...schedule} />);
-                break;
-            case ScheduleTypeEnum.Monthly:
-                component = (
-                    <MonthlyScheduler
-                        schedule={schedule}
-                        onScheduleChanged={onScheduleChanged}
-                        {...schedule} />);
-                break;
-            default:
-                component = null;
-        }
 
         return (
             <div className={classNames('scheduler', className)}>
@@ -98,9 +54,44 @@ export class Scheduler extends React.PureComponent<ISchedulerProps, any> {
                         includeTime={true}
                     />
                 </div>
-                {component}
+                {this.renderInnerComponent(selectedScheduleType,
+                    schedule, onScheduleChanged)}
             </div>
         );
+    }
+
+    renderInnerComponent = (selectedScheduleType, schedule, onScheduleChanged) => {
+        switch (selectedScheduleType) {
+            case ScheduleTypeEnum.OneTime:
+                return null;
+            case ScheduleTypeEnum.Minutely:
+                return (
+                    <MinutelyScheduler
+                        schedule={schedule}
+                        onScheduleChanged={onScheduleChanged} />);
+            case ScheduleTypeEnum.Hourly:
+                return (
+                    <HourlyScheduler
+                        schedule={schedule}
+                        onScheduleChanged={onScheduleChanged} />);
+            case ScheduleTypeEnum.Daily:
+                return (
+                    <DailyScheduler
+                        schedule={schedule}
+                        onScheduleChanged={onScheduleChanged} />);
+            case ScheduleTypeEnum.Weekly:
+                return (
+                    <WeeklyScheduler
+                        schedule={schedule}
+                        onScheduleChanged={onScheduleChanged} />);
+            case ScheduleTypeEnum.Monthly:
+                return (
+                    <MonthlyScheduler
+                        schedule={schedule}
+                        onScheduleChanged={onScheduleChanged} />);
+            default:
+                return null;
+        }
     }
 
     startDateTimeChanged = (date: Date) => {

--- a/src/components/Scheduler/Scheduler.tsx
+++ b/src/components/Scheduler/Scheduler.tsx
@@ -11,7 +11,7 @@ import { MonthlyScheduler } from './InnerSchedulers/MonthlyScheduler';
 import { MinutelyScheduler } from './InnerSchedulers/MinutelyScheduler';
 import './Scheduler.scss';
 
-export class Scheduler extends React.Component<ISchedulerProps, any> {
+export class Scheduler extends React.Component<ISchedulerProps, {}> {
     public static defaultProps = {
         dropdownOptions: [
             { key: ScheduleTypeEnum.OneTime, text: 'One time' },

--- a/src/components/Scheduler/Scheduler.tsx
+++ b/src/components/Scheduler/Scheduler.tsx
@@ -8,6 +8,8 @@ import { DropdownType } from '../Dropdown/Dropdown.Props';
 import { DailyScheduler } from './InnerSchedulers/DailyScheduler';
 import { WeeklyScheduler } from './InnerSchedulers/WeeklyScheduler';
 import { MonthlyScheduler } from './InnerSchedulers/MonthlyScheduler';
+import { MinutelyScheduler } from './InnerSchedulers/MinutelyScheduler';
+import './Scheduler.scss';
 
 export class Scheduler extends React.PureComponent<ISchedulerProps, any> {
     public static defaultProps = {
@@ -38,7 +40,7 @@ export class Scheduler extends React.PureComponent<ISchedulerProps, any> {
                 break;
             case ScheduleTypeEnum.Minutely:
                 component = (
-                    <HourlyScheduler
+                    <MinutelyScheduler
                         schedule={schedule}
                         onScheduleChanged={onScheduleChanged}
                         {...schedule} />);
@@ -78,6 +80,7 @@ export class Scheduler extends React.PureComponent<ISchedulerProps, any> {
         return (
             <div className={classNames('scheduler', className)}>
                 <Dropdown
+                    hasTitleBorder={true}
                     options={dropdownOptions}
                     onChanged={scheduleTypeChanged}
                     label={dropdownLabel}

--- a/src/components/Scheduler/index.ts
+++ b/src/components/Scheduler/index.ts
@@ -1,0 +1,2 @@
+export * from './Scheduler.Props';
+export * from './Scheduler';

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ export * from './components/ServerGridDashboard';
 export * from './components/TreeFilter';
 export * from './components/Wizard';
 export * from './components/MessageBox';
+export * from './components/Scheduler';
 export * from './utilities/autobind';
 export * from './utilities/KeyCodes';
 export * from './utilities/rtl';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,8 @@ module.exports = {
         QuickGrid: "./examples/src/QuickGrid.tsx",
         Tooltip: "./examples/src/Tooltip.tsx",
         Wizard: "./examples/src/Wizard.tsx",
-        MessageBox: "./examples/src/MessageBox.tsx"
+        MessageBox: "./examples/src/MessageBox.tsx",
+        Scheduler: "./examples/src/Scheduler.tsx",
     },
     output: {
         path: path.join(__dirname, '/dist'),


### PR DESCRIPTION
http://take.ms/zhKgr 
 
 - Scheduler takes selectedScheduleType and schedule props which combined comprise the time scheduling structure
 - scheduleTypeChanged and onScheduleChanged props are used to send the new schedule back after it's been altered in the schedule component
 - ChoiceGroup option now has contentBelow property,  used for rendering additional content below the option
 - includeTime prop is added to DateTimeDropdownPicker enabling TimePicker below the DateTime