### PR TITLE
Hotfix for CompareComponent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "quick-react-ts",
-    "version": "0.9.19",
+    "version": "0.9.20",
     "description": "Reusable components for React, written in TypeScript",
     "main": "./lib/index.js",
     "typings": "./lib/index",

--- a/src/components/Compare/CompareComponent.tsx
+++ b/src/components/Compare/CompareComponent.tsx
@@ -276,13 +276,13 @@ class CompareComponentInner extends React.PureComponent<ICompareComponentProp, I
                                     <Button
                                         className={classNames({'compare-button-active' : this.state.missingFilter})}
                                         onClick={this.toggleMissingEntires}
-                                        title={'Show/Hide equal entires'}
+                                        title={'Show/Hide missing entires'}
                                         icon={' icon-arrows'}
                                     />
                                     <Button
                                         className={classNames({'compare-button-active' : this.state.diffFilter})}
                                         onClick={this.toggleNotEqualEntires}
-                                        title={'Show/Hide equal entires'}
+                                        title={'Show/Hide different entires'}
                                         icon={'icon-not_equal'}
                                     />
                                     <Button

--- a/src/components/Compare/CompareComponent.tsx
+++ b/src/components/Compare/CompareComponent.tsx
@@ -333,6 +333,7 @@ class CompareComponentInner extends React.PureComponent<ICompareComponentProp, I
                                                 rowCount={this.targetRows.length}
                                                 columnCount={1}
                                                 scrollTop={scrollTop}
+                                                {...this.differences} // force update on difference change.
                                             />
                                         </div>
                                         <div className={'compare-single-grid-wrapper'}>

--- a/src/components/Compare/CompareComponent.tsx
+++ b/src/components/Compare/CompareComponent.tsx
@@ -87,12 +87,12 @@ class CompareComponentInner extends React.PureComponent<ICompareComponentProp, I
         if (diffOnRow) {
             switch (diffOnRow.differenceType) {
                 case CompareDifferenceType.MissingInSource:
-                    if (isSource) {
+                    if (!isSource) {
                         colorClass = 'compare-missing-in-source';
                     }
                     break;
                 case CompareDifferenceType.MissingInTarget:
-                    if (!isSource) {
+                    if (isSource) {
                         colorClass = 'compare-missing-in-target';
                     }
                     break;
@@ -178,7 +178,7 @@ class CompareComponentInner extends React.PureComponent<ICompareComponentProp, I
                 filteredTargetRows.splice(x - cnt, 1);
                 filteredDiffs.splice(filteredDiffs.indexOf(filteredDiffs.filter((y) => y.rowIndex === x - cnt)[0]), 1);
                 filteredDiffs = filteredDiffs.map((y) => {
-                    if (y.rowIndex >= x) {
+                    if (y.rowIndex >= x - cnt) {
                         y.rowIndex--;
                     }
                     return y;
@@ -199,9 +199,6 @@ class CompareComponentInner extends React.PureComponent<ICompareComponentProp, I
 
         this.columnsMinTotalWidth = props.columns.map(x => x.minWidth || defaultMinColumnWidth).reduce((a, b) => a + b, 0);
         this.columns = props.columns;
-        this.sourceRows = props.sourceRows.map((x) => ({...x}));
-        this.targetRows = props.targetRows.map((x) => ({...x}));
-        this.differences = props.differences.map((x) => ({...x}));
     }
 
     componentWillUpdate(nextProps : ICompareComponentProp, nextState : ICompareComponentState) {
@@ -218,6 +215,7 @@ class CompareComponentInner extends React.PureComponent<ICompareComponentProp, I
             prevProps.targetRows !== this.props.targetRows ||
             prevProps.differences !== this.props.differences) {
                 this.reSetPropeties(this.props);
+                this.reCalculateRows(this.props, this.state);
         }
         if (prevProps.columns !== this.props.columns || prevState.columnWidths !== this.state.columnWidths) {
             this.leftGrid.recomputeGridSize();


### PR DESCRIPTION
Fixed problem of CompareComponent not updating middle grid (one with difference icons) on difference property change.

