### PR TITLE
New resize for quick grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "quick-react-ts",
-    "version": "0.9.21",
+    "version": "0.9.22",
     "description": "Reusable components for React, written in TypeScript",
     "main": "./lib/index.js",
     "typings": "./lib/index",

--- a/src/components/Compare/CompareComponent.tsx
+++ b/src/components/Compare/CompareComponent.tsx
@@ -8,13 +8,12 @@ import { autobind } from '../../utilities/autobind';
 import { AutoSizer, ScrollSync, MultiGrid, Grid } from 'react-virtualized';
 import './CompareComponent.scss';
 import HTML5Backend from 'react-dnd-html5-backend';
-import { DragDropContextProvider, DragDropContext } from 'react-dnd';
 const scrollbarSize = require('dom-helpers/util/scrollbarSize');
 
 import * as classNames from 'classnames';
 
 const defaultMinColumnWidth = 100;
-class CompareComponentInner extends React.PureComponent<ICompareComponentProp, ICompareComponentState> {
+export class CompareComponent extends React.PureComponent<ICompareComponentProp, ICompareComponentState> {
     private sourceRows: Array<any>;
     private targetRows: Array<any>;
     private columns: Array<GridColumn>;
@@ -380,5 +379,3 @@ class CompareComponentInner extends React.PureComponent<ICompareComponentProp, I
             </div>);
     }
 }
-
-export const CompareComponent: React.ComponentClass<ICompareComponentProp> = DragDropContext(HTML5Backend)(CompareComponentInner);

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -14,7 +14,6 @@ import { Dropdown, DropdownType, IDropdownOption } from '../Dropdown';
 import { Icon } from '../Icon/Icon';
 import * as _ from 'lodash';
 import HTML5Backend from 'react-dnd-html5-backend';
-import { DragDropContextProvider, DragDropContext } from 'react-dnd';
 import { groupBy as arrayGroupBy } from '../../utilities/array';
 const createSelector = require('reselect').createSelector;
 import { GridFooter } from './QuickGridFooter';

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -171,7 +171,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
     }
 
     getGridWidth() {
-        return this.getViewportWidth() - scrollbarSize();
+        return this.getViewportWidth();
     }
 
     getGridHeight = (height: number) => {
@@ -481,7 +481,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                                         sortColumn={this.state.sortColumn}
                                         sortDirection={this.state.sortDirection}
                                         onSort={this.onSortColumn}
-                                        width={width - scrollbarSize()}
+                                        width={width}
                                         scrollLeft={scrollLeft}
                                         className={headerClass}
                                         groupBy={this.state.groupBy}
@@ -534,4 +534,4 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
     }
 }
 
-export const QuickGrid: React.ComponentClass<IQuickGridProps> = DragDropContext(HTML5Backend)(QuickGridInner);
+export const QuickGrid: React.ComponentClass<IQuickGridProps> = QuickGridInner;

--- a/src/components/QuickGrid/QuickGridHeader.tsx
+++ b/src/components/QuickGrid/QuickGridHeader.tsx
@@ -7,20 +7,24 @@ import { HeaderColumn } from './HeaderColumn';
 import { Grid, SortIndicator } from 'react-virtualized';
 import { shallowCompareArrayEqual } from '../../utilities/array';
 const DraggableCore = require('react-draggable').DraggableCore;
+import { DragDropContextProvider, DragDropContext } from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
 import * as _ from 'lodash';
 import './QuickGrid.scss';
 
-export class GridHeader extends React.PureComponent<IGridHeaderProps, IGridHeaderState> {
+export class GridHeaderInner extends React.PureComponent<IGridHeaderProps, IGridHeaderState> {
     public static defaultProps = {
         groupBy: []
     };
     private _headerGrid: any;
     private columnMinWidths: Array<number>;
+    private visualWidthChange: number;
     constructor(props: IGridHeaderProps) {
         super(props);
         this.state = {
             columnWidths: props.columnWidths
         };
+        this.visualWidthChange = 0;
         this.columnMinWidths = this.getColumnMinWidths(props.headerColumns);
     }
 
@@ -90,7 +94,7 @@ export class GridHeader extends React.PureComponent<IGridHeaderProps, IGridHeade
         const column = this.props.headerColumns[columnIndex];
         const isAction = this.props.hasActionColumn && columnIndex === 0 || (column.valueMember === undefined && column.dataMember === undefined);
         const notEmptyColumns = !isAction && columnIndex >= this.props.groupBy.length;
-        const displayResizeHandle = notLastIndex && notEmptyColumns;
+        const displayResizeHandle = notEmptyColumns;
 
         return (
             <div
@@ -115,34 +119,144 @@ export class GridHeader extends React.PureComponent<IGridHeaderProps, IGridHeade
     }
 
     onDragHeaderColumn = (e, data, columnIndex) => {
+        const gridWidth = this.props.width;
+        const scrollValue = this._headerGrid._scrollingContainer.scrollLeft;
         this.setState((oldState) => {
-            const columnWidth = oldState.columnWidths[columnIndex];
-            const nextColumnWidth = oldState.columnWidths[columnIndex + 1];
-
-            let newColumnWidth = columnWidth + data.deltaX;
-            let newNextColumnWidth = nextColumnWidth - data.deltaX;
-
-            if (newColumnWidth <= this.columnMinWidths[columnIndex]) {
-                newColumnWidth = this.columnMinWidths[columnIndex];
-                newNextColumnWidth = (columnWidth + nextColumnWidth) - newColumnWidth;
-            }
-            if (newNextColumnWidth <= this.columnMinWidths[columnIndex + 1]) {
-                newNextColumnWidth = this.columnMinWidths[columnIndex + 1];
-                newColumnWidth = (columnWidth + nextColumnWidth) - newNextColumnWidth;
-            }
-
+            const currentColumnWidth = oldState.columnWidths[columnIndex];
             let newColumnWidths = [...oldState.columnWidths];
-            newColumnWidths[columnIndex] = newColumnWidth;
-            newColumnWidths[columnIndex + 1] = newNextColumnWidth;
+            let newCurrentColumnWidth = currentColumnWidth + data.deltaX;
+            let newColumnsTotalWidth = newColumnWidths.reduce(function(acc, val) { return acc + val; });
 
+            // If grid would contain empty space, resize columns.
+            if (gridWidth >= newColumnsTotalWidth) {
+                newColumnWidths[columnIndex] = newCurrentColumnWidth;
+
+                // Ignore changes if user is trying to reduce last column.
+                if (columnIndex === newColumnWidths.length - 1 && data.deltaX < 0) {
+                    newCurrentColumnWidth = currentColumnWidth;
+                } else {                    
+                    // Do not resize below minimum.
+                    if (newCurrentColumnWidth <= this.columnMinWidths[columnIndex]) {
+                        newCurrentColumnWidth = this.columnMinWidths[columnIndex];
+                        newColumnWidths[newColumnWidths.length - 1] += (oldState.columnWidths[columnIndex] - newCurrentColumnWidth);
+                        data.deltaX = newCurrentColumnWidth - oldState.columnWidths[columnIndex];
+                    }
+
+                    // Calculate multiplier by which all columns to the right of the current one will be resized.
+                    let remainingColumnWidth = 0;
+                    for (let index = columnIndex + 1; index < newColumnWidths.length; index++) {
+                        remainingColumnWidth += newColumnWidths[index];
+                    }
+                    let reductionMultiplier = (remainingColumnWidth - data.deltaX) / remainingColumnWidth;
+
+                    // Resize columns by percentage, but do not resize columns below minimum.
+                    let resizeableColumns = [];
+                    let extraWidth = 0;
+                    let availableWidth = 0;
+                    for (let index = columnIndex + 1; index < oldState.columnWidths.length; index++) {
+                        let newWidth = parseFloat((oldState.columnWidths[index] * reductionMultiplier).toFixed(2));
+                        if (newWidth <= this.columnMinWidths[index]) {
+                            extraWidth += parseFloat((this.columnMinWidths[index] - newWidth).toFixed(2));
+                            newColumnWidths[index] = this.columnMinWidths[index];
+                        } else {
+                            resizeableColumns.push({id : index, width: newWidth, min: this.columnMinWidths[index]});
+                            availableWidth += newWidth - this.columnMinWidths[index];
+                            newColumnWidths[index] = newWidth;
+                        }
+                    }
+                    newColumnWidths[columnIndex] = newCurrentColumnWidth;
+
+                    // Split leftover resizes that would resize columns below minimum to other columns.
+                    if (extraWidth > 0 && availableWidth > extraWidth) {
+                        remainingColumnWidth = resizeableColumns.reduce(function(acc, val) { return acc + val.width; }, 0);
+                        reductionMultiplier = (remainingColumnWidth - extraWidth) / remainingColumnWidth;
+
+                        resizeableColumns.sort((x, y) => {
+                            return x.width - y.width;
+                        }).forEach(element => {
+
+                            // Resize columns proportionately.
+                            let newWidth = element.id !== resizeableColumns[resizeableColumns.length - 1].id ?
+                                parseFloat((newColumnWidths[element.id] * reductionMultiplier).toFixed(2)) :
+                                parseFloat((newColumnWidths[element.id] - extraWidth).toFixed(2));
+
+                            if (newWidth < element.min) {
+                                newWidth = element.min;
+                            }
+
+                            // Recalculate width and multiplier.
+                            extraWidth -= parseFloat((newColumnWidths[element.id] - newWidth).toFixed(2));
+                            remainingColumnWidth -= element.width;
+                            reductionMultiplier = (remainingColumnWidth - extraWidth) / remainingColumnWidth;
+                            newColumnWidths[element.id] = newWidth;
+                        });
+
+                        newColumnsTotalWidth = newColumnWidths.reduce(function(acc, val) { return acc + val; });
+                        if (gridWidth !== newColumnsTotalWidth) {
+                            newColumnWidths[newColumnWidths.length - 1] += gridWidth - newColumnsTotalWidth;
+                        }
+                    }
+                    newColumnsTotalWidth = newColumnWidths.reduce(function(acc, val) { return acc + val; });
+
+                    // To ensure columns always fill grid, fixes rounding issues.
+                    if (data.deltaX < 0 && gridWidth !== newColumnsTotalWidth) {
+                        newColumnWidths[newColumnWidths.length - 1] += gridWidth - newColumnsTotalWidth;
+                    }
+                }
+            } else {
+
+                 // Do not resize below minimum.
+                if (newCurrentColumnWidth <= this.columnMinWidths[columnIndex]) {
+                    newCurrentColumnWidth = this.columnMinWidths[columnIndex];
+                }
+            }
+
+            newColumnWidths[columnIndex] = newCurrentColumnWidth;
+            newColumnsTotalWidth = newColumnWidths.reduce(function(acc, val) { return acc + val; });
+
+            // Special case when user is trying to reduce column size while being scrolled all the way to the right.
+            // Expand last column so user can see dragging, but save expand value so it can be removed later since this is only visual change.
+            if (columnIndex !== newColumnWidths.length - 1 && data.deltaX < 0 && gridWidth < newColumnsTotalWidth && (scrollValue + gridWidth) >= newColumnsTotalWidth) {
+                newColumnWidths[newColumnWidths.length - 1] = newColumnWidths[newColumnWidths.length - 1] - data.deltaX;
+                this.visualWidthChange -= data.deltaX;
+            }
             return { ...oldState, columnWidths: newColumnWidths };
         });
         this._headerGrid.recomputeGridSize({ columnIndex: columnIndex, rowIndex: 0 });
-
     }
 
-    onDragHeaderStop = (e, data, key) => {
-        this.props.onResize(this.state.columnWidths);
+    onDragHeaderStop = (e, data, columnIndex) => {
+        
+        // On stop remove visual expand on last column.
+        let snapColumnWidth = this.state.columnWidths.map((x) => x);
+
+        if (this.visualWidthChange > 0) {
+            snapColumnWidth[snapColumnWidth.length - 1] -= this.visualWidthChange;
+            this.visualWidthChange = 0;
+
+            // In case visual expand caused grid to contain empty space.
+            let sumWidth = snapColumnWidth.reduce(function(acc, val) { return acc + val; });
+            if (this.props.width > sumWidth) {
+
+                let columnCount = snapColumnWidth.length;
+                let totalWidth = 0;
+                for (let index = columnIndex + 1; index < snapColumnWidth.length; index++) {
+                    totalWidth += snapColumnWidth[index];
+                }
+                let remainingWidth = (this.props.width - sumWidth);
+                let percentage = remainingWidth / totalWidth;
+                
+                for (let index = columnIndex + 1; index < snapColumnWidth.length; index++) {
+                    let newWidth = snapColumnWidth[index] + parseFloat((snapColumnWidth[index] * percentage).toFixed(2));
+                    snapColumnWidth[index] = newWidth;            
+                }
+            }
+        }
+        
+        this.setState((oldState) => {
+            return { ...oldState, columnWidths: snapColumnWidth };
+        });
+        this.props.onResize(snapColumnWidth);
     }
 
     createHeaderColumn(column: GridColumn) {
@@ -176,3 +290,5 @@ export class GridHeader extends React.PureComponent<IGridHeaderProps, IGridHeade
         );
     }
 }
+
+export const GridHeader: React.ComponentClass<IGridHeaderProps> = DragDropContext(HTML5Backend)(GridHeaderInner);


### PR DESCRIPTION
Refactored column resize in quick grid

- user can now increase column size without limits (no longer restricted by another column)

- decrease of column width only increases other column size to ensure grid does not contain empty space
