### PR TITLE
Upgrade es5 to es6

### DIFF
--- a/src/components/Compare/CompareComponent.tsx
+++ b/src/components/Compare/CompareComponent.tsx
@@ -81,7 +81,7 @@ export class CompareComponent extends React.PureComponent<ICompareComponentProp,
     public cellRenderer = ({ columnIndex, key, rowIndex, style }, isSource = true) => {
         const columnValue = this.columns[columnIndex].valueMember;
         const value = isSource ? this.sourceRows[rowIndex][columnValue] : this.targetRows[rowIndex][columnValue];
-        const diffOnRow = this.differences.filter(item => item.rowIndex === rowIndex)[0];
+        const diffOnRow = this.differences.find(item => item.rowIndex === rowIndex);
         let colorClass = '';
         if (diffOnRow) {
             switch (diffOnRow.differenceType) {
@@ -115,7 +115,7 @@ export class CompareComponent extends React.PureComponent<ICompareComponentProp,
         );
     }
     public cellRendererMiddle = ({ columnIndex, key, rowIndex, style }) => {
-        const diffOnRow = this.differences.filter(item => item.rowIndex === rowIndex)[0];
+        const diffOnRow = this.differences.find(item => item.rowIndex === rowIndex);
         let iconName = 'icon-equal';
         if (diffOnRow) {
             switch (diffOnRow.differenceType) {
@@ -175,7 +175,7 @@ export class CompareComponent extends React.PureComponent<ICompareComponentProp,
             removeRows.map((x, index) => {
                 filteredSourceRows.splice(x - cnt, 1);
                 filteredTargetRows.splice(x - cnt, 1);
-                filteredDiffs.splice(filteredDiffs.indexOf(filteredDiffs.filter((y) => y.rowIndex === x - cnt)[0]), 1);
+                filteredDiffs.splice(filteredDiffs.indexOf(filteredDiffs.find((y) => y.rowIndex === x - cnt)), 1);
                 filteredDiffs = filteredDiffs.map((y) => {
                     if (y.rowIndex >= x - cnt) {
                         y.rowIndex--;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "buildOnSave": false,
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
+    "target": "es6",
     "jsx": "react",
     "skipLibCheck": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
There is no reason why quick-react-ts should be on version es5. Therefore I upgraded it to es6, while also implemented new es6 find in Compare to make sure everything is working properly.

Also useful link for es6 :
https://webapplog.com/es6/