### PR TITLE
Callback when callout is closed

### DIFF
--- a/examples/src/TreeFilter.tsx
+++ b/examples/src/TreeFilter.tsx
@@ -52,6 +52,7 @@ export class Index extends React.Component<any, DemoState> {
                     defaultSelection={FilterSelectionEnum.All}
                     maxWidth={700}
                     maxHeight={500}
+                    onCalloutClose={() => console.log('closing...')}
                 />
                 <br /><br />
 

--- a/src/components/TreeFilter/TreeFilter.Props.ts
+++ b/src/components/TreeFilter/TreeFilter.Props.ts
@@ -52,6 +52,7 @@ export interface ITreeFilterProps {
         bottomLeft: boolean,
         topLeft: boolean
     };
+    onCalloutClose?(): void;
 }
 
 export const defaultTreeFilterProps: Partial<ITreeFilterProps> = {
@@ -69,7 +70,8 @@ export const defaultTreeFilterProps: Partial<ITreeFilterProps> = {
     defaultSelection: FilterSelectionEnum.None,
     clearSearchOnClose: true,
     rowHeight: 21,
-    showButtons: false
+    showButtons: false,
+    onCalloutClose: () => { }
 };
 
 export interface ITreeFilterState {

--- a/src/components/TreeFilter/TreeFilter.tsx
+++ b/src/components/TreeFilter/TreeFilter.tsx
@@ -108,8 +108,9 @@ export class TreeFilter extends React.PureComponent<ITreeFilterProps, ITreeFilte
         this.setState(prevState => ({ ...prevState, isOpen: !prevState.isOpen }));
     }
 
-    onDismiss = () => {
+    private onDismiss = () => {
         this.setState(prevState => ({ ...prevState, isOpen: false }));
+        this.props.onCalloutClose();
     }
 
     private getBoxSupportElementsHeight = () => {
@@ -190,6 +191,7 @@ export class TreeFilter extends React.PureComponent<ITreeFilterProps, ITreeFilte
             selection: this.props.filterSelection,
             selectionText: this.getSelectedText(this.props.filterSelection, this.lookups.itemLookup)
         }));
+        this.props.onCalloutClose();
     }
 
     @autobind
@@ -199,6 +201,7 @@ export class TreeFilter extends React.PureComponent<ITreeFilterProps, ITreeFilte
         }
 
         this.setState(prevState => ({ ...prevState, isOpen: false, selection: this.state.selection }));
+        this.props.onCalloutClose();
     }
 
     private _getAllItemIds = () => this.allItemIds;


### PR DESCRIPTION
When callout on treefilter is closed callback will be invoked, if defined. This gives opportunity for end user of component to define specific behaviour when callout is closed and no buttons provided, because onValuesSelected prop gets invoked on every selection.