### PR TITLE
remove TagContainer because it was duplicate

### DIFF
--- a/src/components/TileDashboard/TileDashboard.tsx
+++ b/src/components/TileDashboard/TileDashboard.tsx
@@ -173,19 +173,7 @@ export class TileDashboard extends React.Component<ITileDashboardProps, ITileDas
                     countersData={getServerMeasures(server.measures)}
                     diskInformation={getDiskInformationFromMeasurements(server.measures)}
                     serverOnClick={this.serverOnClick}
-                    hoverMessageForCriticalOrWarningServer={this.props.hoverMessageForCriticalOrWarningServer}
-                >
-                    {
-                        server.roles.length > 0 &&
-                        <TagContainer title={''} tags={server.roles} >
-                            {
-                                this.props.onServerRoleEdit &&
-                                <div className="edit-tags tag" title="Edit roles" onClick={(event) => this.onRoleEdit(server.id)}>
-                                    <Icon className="icon-edit"></Icon>
-                                </div>
-                            }
-                        </TagContainer>
-                    }
+                    hoverMessageForCriticalOrWarningServer={this.props.hoverMessageForCriticalOrWarningServer}> 
                 </ServerTile>
             </div>
         );


### PR DESCRIPTION
Remove duplicate TagContainer from Tile Dashboard when grouping is None