### PR TITLE
Feat/people picker

### DIFF
--- a/examples/MockData/peoplePickerData.ts
+++ b/examples/MockData/peoplePickerData.ts
@@ -1,12 +1,9 @@
 import { IPrincipal } from '../../src/components/PeoplePicker/Principal.Props';
 
 export const peoplePickerData: IPrincipal[] = [
-    { id: 1, displayName: 'FirstName1 LastName1', email: 'username1@domain1' },
-    { id: 2, displayName: 'FirstName2 LastName2', email: 'username2@domain2' },
-    { id: 3, displayName: 'FirstName3 LastName3', email: 'username3@domain3' },
-    { id: 4, displayName: 'FirstName4 LastName4', email: 'username4@domain4' },
-    { id: 5, displayName: 'FirstName5 LastName5', email: 'username5@domain5' },
-    { id: 6, displayName: 'aaaa aaaccc', email: 'username6@domain6' },
-    { id: 7, displayName: 'bbbb bbbbbbb', email: 'username7@domain7' },
-    { id: 8, displayName: 'aaaaaaa aaaaa', email: 'username8@domain8'}
+    { id: 1, displayName: 'FirstName1 LastName1', email: 'username1@domain1', type: 0 },
+    { id: 2, displayName: 'FirstName2 LastName2', email: 'username2@domain2', type: 1 },
+    { id: 3, displayName: 'FirstName3 LastName3', email: 'username3@domain3', type: 2 },
+    { id: 4, displayName: 'FirstName4 LastName4', email: 'username4@domain4', type: 3 },
+    { id: 5, displayName: 'FirstName5 LastName5', email: 'username5@domain5', type: 0 }
 ];

--- a/examples/MockData/peoplePickerData.ts
+++ b/examples/MockData/peoplePickerData.ts
@@ -1,0 +1,12 @@
+import { IPrincipal } from '../../src/components/PeoplePicker/Principal.Props';
+
+export const peoplePickerData: IPrincipal[] = [
+    { id: 1, displayName: 'FirstName1 LastName1', email: 'username1@domain1' },
+    { id: 2, displayName: 'FirstName2 LastName2', email: 'username2@domain2' },
+    { id: 3, displayName: 'FirstName3 LastName3', email: 'username3@domain3' },
+    { id: 4, displayName: 'FirstName4 LastName4', email: 'username4@domain4' },
+    { id: 5, displayName: 'FirstName5 LastName5', email: 'username5@domain5' },
+    { id: 6, displayName: 'aaaa aaaccc', email: 'username6@domain6' },
+    { id: 7, displayName: 'bbbb bbbbbbb', email: 'username7@domain7' },
+    { id: 8, displayName: 'aaaaaaa aaaaa', email: 'username8@domain8'}
+];

--- a/examples/pages/PeoplePicker.html
+++ b/examples/pages/PeoplePicker.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <title>PeoplePicker</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="PeoplePicker.js"></script>
+  </body>
+</html>

--- a/examples/src/PeoplePicker.tsx
+++ b/examples/src/PeoplePicker.tsx
@@ -33,6 +33,9 @@ export class Index extends React.Component<any, any> {
                 <PeoplePicker 
                     labelText="Disabled PeoplePicker "
                     disabled={true}
+                    onSearch={this._handleSearch}
+                    onSelect={this._handleSelect}
+                    suggestionList={peoplePickerData}
                 />
                 <br/>
                 <PeoplePicker 

--- a/examples/src/PeoplePicker.tsx
+++ b/examples/src/PeoplePicker.tsx
@@ -5,12 +5,56 @@ import 'ts-helpers';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { PeoplePicker } from '../../src/components/PeoplePicker/PeoplePicker';
+import { peoplePickerData } from '../MockData/peoplePickerData';
+import { autobind } from '../../src/utilities/autobind';
+import { IPrincipal } from '../../src/components/PeoplePicker/Principal.Props';
+
 
 export class Index extends React.Component<any, any> {
+    private _handleSelect(selectedPersonList: IPrincipal[]) {
+        // console.log(selectedPersonList);
+    }
+
+    private _handleSearch(searchedValue: string) {
+       // console.log(searchedValue);
+    }
+
     public render() {
         return (
-            <div style={{ width: '500px' }}>
-                <PeoplePicker />
+            <div style={{ width: '900px' }}>
+                <PeoplePicker 
+                    iconName={'icon-user'}
+                    labelText="PeoplePicker"
+                    onSearch={this._handleSearch}
+                    onSelect={this._handleSelect}
+                    placeholder="Search for people"
+                    suggestionList={peoplePickerData}
+                />
+                <br/>
+                <PeoplePicker 
+                    labelText="Disabled PeoplePicker "
+                    disabled={true}
+                />
+                <br/>
+                <PeoplePicker 
+                    errorMessage="This is error message! This is error message!"
+                    iconName={'icon-user'}
+                    labelText="Error PeoplePicker"
+                    onSearch={this._handleSearch}
+                    onSelect={this._handleSelect}
+                    placeholder="Search for people"
+                    suggestionList={peoplePickerData}
+                />
+                <br/>
+                <PeoplePicker 
+                    iconName={'icon-user'}
+                    labelText="Single Select PeoplePicker"
+                    onSearch={this._handleSearch}
+                    onSelect={this._handleSelect}
+                    placeholder="Search for people"
+                    singleSelect={true}
+                    suggestionList={peoplePickerData}
+                />
             </div>
         );
     }

--- a/examples/src/PeoplePicker.tsx
+++ b/examples/src/PeoplePicker.tsx
@@ -1,0 +1,18 @@
+/* tslint:disable:no-console */
+import 'babel-polyfill';
+import 'ts-helpers';
+
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { PeoplePicker } from '../../src/components/PeoplePicker/PeoplePicker';
+
+export class Index extends React.Component<any, any> {
+    public render() {
+        return (
+            <div style={{ width: '500px' }}>
+                <PeoplePicker />
+            </div>
+        );
+    }
+}
+ReactDOM.render(<Index />, document.getElementById('root'));

--- a/examples/src/PeoplePicker.tsx
+++ b/examples/src/PeoplePicker.tsx
@@ -23,7 +23,6 @@ export class Index extends React.Component<any, any> {
         return (
             <div style={{ width: '900px' }}>
                 <PeoplePicker 
-                    iconName={'icon-user'}
                     labelText="PeoplePicker"
                     onSearch={this._handleSearch}
                     onSelect={this._handleSelect}
@@ -38,7 +37,6 @@ export class Index extends React.Component<any, any> {
                 <br/>
                 <PeoplePicker 
                     errorMessage="This is error message! This is error message!"
-                    iconName={'icon-user'}
                     labelText="Error PeoplePicker"
                     onSearch={this._handleSearch}
                     onSelect={this._handleSelect}
@@ -47,7 +45,6 @@ export class Index extends React.Component<any, any> {
                 />
                 <br/>
                 <PeoplePicker 
-                    iconName={'icon-user'}
                     labelText="Single Select PeoplePicker"
                     onSearch={this._handleSearch}
                     onSelect={this._handleSelect}

--- a/src/components/PeoplePicker/PeoplePicker.Props.ts
+++ b/src/components/PeoplePicker/PeoplePicker.Props.ts
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { PeoplePicker } from './PeoplePicker';
+
+export interface IPeoplePickerProps extends React.Props<PeoplePicker> {
+    labelText?: string;
+    onChange?: (newValue: any) => void;
+    onChanged?: (newValue: any) => void;
+    disabled?: boolean;
+    className?: string;
+}

--- a/src/components/PeoplePicker/PeoplePicker.Props.ts
+++ b/src/components/PeoplePicker/PeoplePicker.Props.ts
@@ -8,9 +8,9 @@ export interface IPeoplePickerProps extends React.Props<PeoplePicker> {
     errorMessage?: string;
     labelText?: string;
     loadingSuggestionList?: boolean;
-    onSearch?: (searchedValue: string) => void;
-    onSelect?: (selectedPersonList: IPrincipal[]) => void;
+    onSearch: (searchedValue: string) => void;
+    onSelect: (selectedPersonList: IPrincipal[]) => void;
     placeholder?: string;
     singleSelect?: boolean;
-    suggestionList?: IPrincipal[]; 
+    suggestionList: IPrincipal[]; 
 }

--- a/src/components/PeoplePicker/PeoplePicker.Props.ts
+++ b/src/components/PeoplePicker/PeoplePicker.Props.ts
@@ -6,7 +6,6 @@ export interface IPeoplePickerProps extends React.Props<PeoplePicker> {
     className?: string;
     disabled?: boolean;
     errorMessage?: string;
-    iconName?: string;
     labelText?: string;
     loadingSuggestionList?: boolean;
     onSearch?: (searchedValue: string) => void;

--- a/src/components/PeoplePicker/PeoplePicker.Props.ts
+++ b/src/components/PeoplePicker/PeoplePicker.Props.ts
@@ -1,10 +1,17 @@
 import * as React from 'react';
 import { PeoplePicker } from './PeoplePicker';
+import { IPrincipal } from './Principal.Props';
 
 export interface IPeoplePickerProps extends React.Props<PeoplePicker> {
-    labelText?: string;
-    onChange?: (newValue: any) => void;
-    onChanged?: (newValue: any) => void;
-    disabled?: boolean;
     className?: string;
+    disabled?: boolean;
+    errorMessage?: string;
+    iconName?: string;
+    labelText?: string;
+    loadingSuggestionList?: boolean;
+    onSearch?: (searchedValue: string) => void;
+    onSelect?: (selectedPersonList: IPrincipal[]) => void;
+    placeholder?: string;
+    singleSelect?: boolean;
+    suggestionList?: IPrincipal[]; 
 }

--- a/src/components/PeoplePicker/PeoplePicker.scss
+++ b/src/components/PeoplePicker/PeoplePicker.scss
@@ -44,7 +44,6 @@
         border: 1px solid $white-background-lines;
         border-radius: 8px;
         border-color: $primary-color;
-        //padding: 5px 10px 6px 10px;
         width: calc(100% - 30px);
         outline: 0;
     }
@@ -77,13 +76,40 @@
         }
     }
 
-    .peoplePicker-error-icon {
+    .people-picker-error-icon {
         position: relative;
         left: -20px;
 
         .icon {
             font-size: 12px;
             color: $error-color;
+        }
+    }
+
+    .people-picker-input-error-container {
+        .people-picker-input-error-info-container {
+            float: right;
+            position: relative;
+            top: -25px;
+            left: -1px;
+        }
+    }
+
+    .people-picker-input-error {
+        box-sizing: border-box;
+        border: 1px solid $error-color;
+        border-radius: 8px;
+        padding: 5px 10px 6px 10px;
+        width: calc(100% - 30px);
+        outline: 0;
+    
+        &:hover {
+            border-color: $error-color;
+        }
+    
+        &:active,
+        &:focus {
+            border-color: $error-color;
         }
     }
 }

--- a/src/components/PeoplePicker/PeoplePicker.scss
+++ b/src/components/PeoplePicker/PeoplePicker.scss
@@ -1,7 +1,17 @@
 @import '../../index.scss';
 
-.people-picker-container {
-    .people-picker-input{
+.people-picker {
+    .label {
+        margin-left: 2px;
+    }
+
+    &.is-disabled {
+        .label {        
+            color: $secondary-disabled-color;
+        }
+    }
+
+    .people-picker-input {
         box-sizing: border-box;
         border: 1px solid $white-background-lines;
         border-radius: 8px;
@@ -18,24 +28,62 @@
             border-color: $primary-color;
         }
     
-        &[disabled] {
+        &.is-disabled {
             background-color: $disabled-field;
             border-color: $white-background-lines;
             color: $secondary-disabled-color;
             pointer-events: none;
             cursor: default;
         }
+    }
 
-        &.textField-field-unresizable {
-            resize: none;
+    .people-picker-suggestions {
+        display: flex;
+        flex-direction: column;
+        box-sizing: border-box;
+        border: 1px solid $white-background-lines;
+        border-radius: 8px;
+        border-color: $primary-color;
+        //padding: 5px 10px 6px 10px;
+        width: calc(100% - 30px);
+        outline: 0;
+    }
+
+    .people-picker-selected {
+        box-sizing: border-box;
+        border: 1px solid $white-background-lines;
+        border-radius: 8px;
+        padding: 5px 10px 6px 10px;
+        width: calc(100% - 30px);
+        outline: 0;
+        
+        .people-picker-selected-input{
+            border: none!important;        
+            outline: 0!important;
+            padding-left: 5px!important;
         }
 
-        &.textField-invalid {
-            border-color: $error-color;
+        &:hover {
+            border-color: $white-background-lines-hover;
+        }
+        
+        &:active,
+        &:focus {
+            border-color: $primary-color;
+        }
 
-            &:hover {
-                border-color: $error-color;
-            }
+        &.is-active {
+            border-color: $primary-color;
+        }
+    }
+
+    .peoplePicker-error-icon {
+        position: relative;
+        left: -20px;
+
+        .icon {
+            font-size: 12px;
+            color: $error-color;
         }
     }
 }

--- a/src/components/PeoplePicker/PeoplePicker.scss
+++ b/src/components/PeoplePicker/PeoplePicker.scss
@@ -79,11 +79,8 @@
     .people-picker-error-icon {
         position: relative;
         left: -20px;
-
-        .icon {
-            font-size: 12px;
-            color: $error-color;
-        }
+        font-size: 12px;
+        color: $error-color;
     }
 
     .people-picker-input-error-container {

--- a/src/components/PeoplePicker/PeoplePicker.scss
+++ b/src/components/PeoplePicker/PeoplePicker.scss
@@ -1,0 +1,41 @@
+@import '../../index.scss';
+
+.people-picker-container {
+    .people-picker-input{
+        box-sizing: border-box;
+        border: 1px solid $white-background-lines;
+        border-radius: 8px;
+        padding: 5px 10px 6px 10px;
+        width: calc(100% - 30px);
+        outline: 0;
+    
+        &:hover {
+            border-color: $white-background-lines-hover;
+        }
+    
+        &:active,
+        &:focus {
+            border-color: $primary-color;
+        }
+    
+        &[disabled] {
+            background-color: $disabled-field;
+            border-color: $white-background-lines;
+            color: $secondary-disabled-color;
+            pointer-events: none;
+            cursor: default;
+        }
+
+        &.textField-field-unresizable {
+            resize: none;
+        }
+
+        &.textField-invalid {
+            border-color: $error-color;
+
+            &:hover {
+                border-color: $error-color;
+            }
+        }
+    }
+}

--- a/src/components/PeoplePicker/PeoplePicker.tsx
+++ b/src/components/PeoplePicker/PeoplePicker.tsx
@@ -76,6 +76,10 @@ export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeopl
         }
     }
 
+    @autobind _ref(value: HTMLInputElement) {
+        this._field = value;
+    }
+
     @autobind
     private _renderEmptyField(): JSX.Element {
         const peoplePickerInputClassName = classNames(
@@ -90,7 +94,7 @@ export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeopl
             return (
                 <input
                     type={'text'}
-                    ref={(c): HTMLInputElement => this._field = c}
+                    ref={this._ref}
                     value={this.state.value}
                     onBlur={this._onBlur}
                     onFocus={this._onFocus}
@@ -111,7 +115,7 @@ export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeopl
                     <div className="people-picker-input-error-content">
                         <input
                             type={'text'}
-                            ref={(c): HTMLInputElement => this._field = c}
+                            ref={this._ref}
                             value={this.state.value}
                             onBlur={this._onBlur}
                             onFocus={this._onFocus}
@@ -119,9 +123,7 @@ export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeopl
                             className="people-picker-input-error"
                             placeholder={this.props.placeholder}
                         />
-                        <span className="people-picker-error-icon">
-                            <Icon iconName={'icon-warning2'}></Icon>
-                        </span>
+                        <Icon iconName="icon-warning2" className="people-picker-error-icon"></Icon>
                     </div>
                 </Tooltip>
             </div>
@@ -147,7 +149,7 @@ export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeopl
                         <Principal
                             principal={principal}
                             isSelected={true}
-                            onDelete={() => this._onSuggestionDelete(principal.id)}
+                            onDelete={this._onSuggestionDelete}
                         />
                     ))}
                 </div>
@@ -159,12 +161,12 @@ export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeopl
                         <Principal
                             principal={principal}
                             isSelected={true}
-                            onDelete={() => this._onSuggestionDelete(principal.id)}
+                            onDelete={this._onSuggestionDelete}
                         />
                     ))}
                     <input
                         type={'text'}
-                        ref={(c): HTMLInputElement => this._field = c}
+                        ref={this._ref}
                         value={this.state.value}
                         onChange={this._onInputChange}
                         onFocus={this._onFocus}
@@ -187,9 +189,9 @@ export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeopl
     }
 
     @autobind
-    private _onSuggestionDelete(principalId: number) {
+    private _onSuggestionDelete(selectedPrincipal: IPrincipal) {
         const newPrincipalList = this.state.selectedPrincipalList.filter((principal, index) => {
-            if (principal.id !== principalId) {
+            if (principal.id !== selectedPrincipal.id) {
                 return principal;
             }
         });

--- a/src/components/PeoplePicker/PeoplePicker.tsx
+++ b/src/components/PeoplePicker/PeoplePicker.tsx
@@ -3,26 +3,36 @@ import * as classNames from 'classnames';
 import { IPeoplePickerProps } from './PeoplePicker.Props';
 import { getId } from '../../utilities/getId';
 import { autobind } from '../../utilities/autobind';
-import { CommonComponent } from '../Common/Common';
 import './PeoplePicker.scss';
-import { Search } from '../Search/Search';
+import { Principal } from './Principal';
+import { Label } from './../../../src/components/Label/Label';
+import { IPrincipal } from './Principal.Props';
+import { Spinner } from '../Spinner/Spinner';
+import { SpinnerType } from '../Spinner/Spinner.Props';
+import { Tooltip } from '../Tooltip/Tooltip';
+import { DirectionalHint } from '../../utilities/DirectionalHint';
+import { Icon } from '../Icon/Icon';
 
 export interface IPeoplePickerState {
-    value?: string;
-    isFocused?: boolean;
     errorMessage?: string;
+    isFocused?: boolean;
+    selectedPrincipalList?: IPrincipal[];
+    suggestionsVisible?: boolean;
+    value?: any;
 }
 
-export class PeoplePicker extends CommonComponent<IPeoplePickerProps, IPeoplePickerState> {
+export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeoplePickerState> {
     private _field;
 
     constructor(props) {
         super(props);
 
         this.state = {
-            value: props.value || props.defaultValue || '',
+            errorMessage: '',
             isFocused: false,
-            errorMessage: ''
+            selectedPrincipalList: null,
+            suggestionsVisible: false,
+            value: props.value || props.defaultValue || ''
         };
 
         this._onInputChange = this._onInputChange.bind(this);
@@ -30,26 +40,179 @@ export class PeoplePicker extends CommonComponent<IPeoplePickerProps, IPeoplePic
 
     private _onInputChange(event: React.ChangeEvent<any>): void {
         const element: HTMLTextAreaElement = event.target as HTMLTextAreaElement;
-        const value: string = element.value;
+        const value: any = element.value;
 
         this.setState({
-            value: value,
-            errorMessage: ''
-        } as IPeoplePickerState);
+            value: value
+        });
 
-        console.log(value);
+        if (value.length >= 3) {
+            this.setState({ suggestionsVisible: true });
+            this.props.onSearch(value);
+        } else {
+            this.setState({ suggestionsVisible: false });
+        }
+    }
+
+    private _renderSuggestions(): JSX.Element {
+        return (
+            <div className="people-picker-suggestions">
+                {this.props.loadingSuggestionList && <Spinner type={SpinnerType.small} />}
+                {!this.props.loadingSuggestionList && this.props.suggestionList.map((principal, index) => (
+                    <Principal
+                        iconName={this.props.iconName}
+                        principal={principal}
+                        isSelected={false}
+                        onSelect={this._onSuggestionClick}
+                    />
+                ))}
+            </div>
+        );
+    }
+
+    @autobind
+    private _onSuggestionClick(principal: IPrincipal) {
+        this.setState({ suggestionsVisible: false, value: '' });
+
+        if (this.state.selectedPrincipalList !== null) {
+            this.setState({ selectedPrincipalList: [...this.state.selectedPrincipalList, principal] });
+        } else {
+            this.setState({ selectedPrincipalList: [principal] });
+        }
+    }
+
+    @autobind
+    private _renderEmptyField(): JSX.Element {
+        const peoplePickerInputClassName = classNames(
+            'people-picker-input',
+            {
+                'is-disabled': this.props.disabled
+            },
+            [this.props.className]
+        );
+
+        return (
+            <input
+                type={'text'}
+                ref={(c): HTMLInputElement => this._field = c}
+                value={this.state.value}
+                onBlur={this._onBlur}
+                onFocus={this._onFocus}
+                onChange={this._onInputChange}
+                className={peoplePickerInputClassName}
+                placeholder={this.props.placeholder}
+            />
+        );
+    }
+
+    @autobind
+    private _renderSelectedPrincipal(): JSX.Element {
+        this.props.onSelect(this.state.selectedPrincipalList);
+
+        const peoplePickerSelectedClassName = classNames(
+            'people-picker-selected',
+            {
+                'is-active': this.state.isFocused
+            },
+            [this.props.className]
+        );
+
+        if (this.props.singleSelect) {
+            return (
+                <div>
+                    {this.state.selectedPrincipalList && this.state.selectedPrincipalList.map((principal, index) => (
+                        <Principal
+                            iconName={this.props.iconName}
+                            principal={principal}
+                            isSelected={true}
+                            onDelete={() => this._onSuggestionDelete(principal.id)}
+                        />
+                    ))}
+                </div>
+            );
+        } else {
+            return (
+                <div className={peoplePickerSelectedClassName}>
+                    {this.state.selectedPrincipalList && this.state.selectedPrincipalList.map((principal, index) => (
+                        <Principal
+                            iconName={this.props.iconName}
+                            principal={principal}
+                            isSelected={true}
+                            onDelete={() => this._onSuggestionDelete(principal.id)}
+                        />
+                    ))}
+                    <input
+                        type={'text'}
+                        ref={(c): HTMLInputElement => this._field = c}
+                        value={this.state.value}
+                        onChange={this._onInputChange}
+                        onFocus={this._onFocus}
+                        onBlur={this._onBlur}
+                        className="people-picker-selected-input"
+                        onKeyDown={this._handleOnKeyDown}
+                    />
+                </div>
+            );
+        }
+    }
+
+    @autobind
+    private _handleOnKeyDown(event: React.KeyboardEvent<any>): void {
+        if (event.key === 'Backspace') {
+            if (this.state.value.length === 0) {
+                this._onSuggestionDeleteLast();
+            }
+        }
+    }
+
+    @autobind
+    private _onSuggestionDelete(principalId: number) {
+        const newPrincipalList = this.state.selectedPrincipalList.filter((principal, index) => {
+            if (principal.id !== principalId) {
+                return principal;
+            }
+        });
+        this.setState({ selectedPrincipalList: newPrincipalList });
+    }
+
+    @autobind
+    private _onSuggestionDeleteLast() {
+        const oldPrincipalList = this.state.selectedPrincipalList;
+        this.setState({ selectedPrincipalList: oldPrincipalList.slice(0, oldPrincipalList.length - 1) });
+    }
+
+    @autobind
+    private _onFocus(ev: React.FocusEvent<any>) {
+        this.setState({
+            isFocused: true
+        });
+    }
+
+    @autobind
+    private _onBlur(ev: React.FocusEvent<any>) {
+        this.setState({
+            isFocused: false
+        });
     }
 
     public render() {
+        let { disabled, className } = this.props;
+
+        const peoplePickerClassName = classNames(
+            'people-picker',
+            {
+                'is-disabled': disabled
+            },
+            [this.props.className]
+        );
+
         return (
-            <div className="people-picker-container">
-                <input
-                    type={'text'}
-                    ref={(c): HTMLInputElement => this._field = c}
-                    value={this.state.value}
-                    onChange={this._onInputChange}
-                    className="people-picker-input"
-                />
+            <div className={peoplePickerClassName}>
+                {this.props.labelText && <Label >{this.props.labelText}</Label>}
+                {this.state.selectedPrincipalList === null && this._renderEmptyField()}
+                {this.state.selectedPrincipalList !== null && this.state.selectedPrincipalList.length > 0 && this._renderSelectedPrincipal()}
+                {this.state.selectedPrincipalList !== null && this.state.selectedPrincipalList.length === 0 && this._renderEmptyField()}
+                {this.state.suggestionsVisible && this._renderSuggestions()}
             </div>
         );
     }

--- a/src/components/PeoplePicker/PeoplePicker.tsx
+++ b/src/components/PeoplePicker/PeoplePicker.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { IPeoplePickerProps } from './PeoplePicker.Props';
-import { getId } from '../../utilities/getId';
 import { autobind } from '../../utilities/autobind';
 import './PeoplePicker.scss';
 import { Principal } from './Principal';
@@ -14,7 +13,6 @@ import { DirectionalHint } from '../../utilities/DirectionalHint';
 import { Icon } from '../Icon/Icon';
 
 export interface IPeoplePickerState {
-    errorMessage?: string;
     isFocused?: boolean;
     selectedPrincipalList?: IPrincipal[];
     suggestionsVisible?: boolean;
@@ -28,16 +26,14 @@ export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeopl
         super(props);
 
         this.state = {
-            errorMessage: '',
             isFocused: false,
             selectedPrincipalList: null,
             suggestionsVisible: false,
             value: props.value || props.defaultValue || ''
         };
-
-        this._onInputChange = this._onInputChange.bind(this);
     }
 
+    @autobind
     private _onInputChange(event: React.ChangeEvent<any>): void {
         const element: HTMLTextAreaElement = event.target as HTMLTextAreaElement;
         const value: any = element.value;
@@ -60,7 +56,6 @@ export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeopl
                 {this.props.loadingSuggestionList && <Spinner type={SpinnerType.small} />}
                 {!this.props.loadingSuggestionList && this.props.suggestionList.map((principal, index) => (
                     <Principal
-                        iconName={this.props.iconName}
                         principal={principal}
                         isSelected={false}
                         onSelect={this._onSuggestionClick}
@@ -91,17 +86,45 @@ export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeopl
             [this.props.className]
         );
 
+        if (!this.props.errorMessage) {
+            return (
+                <input
+                    type={'text'}
+                    ref={(c): HTMLInputElement => this._field = c}
+                    value={this.state.value}
+                    onBlur={this._onBlur}
+                    onFocus={this._onFocus}
+                    onChange={this._onInputChange}
+                    className={peoplePickerInputClassName}
+                    placeholder={this.props.placeholder}
+                />
+            );
+        }
+
         return (
-            <input
-                type={'text'}
-                ref={(c): HTMLInputElement => this._field = c}
-                value={this.state.value}
-                onBlur={this._onBlur}
-                onFocus={this._onFocus}
-                onChange={this._onInputChange}
-                className={peoplePickerInputClassName}
-                placeholder={this.props.placeholder}
-            />
+            <div className="people-picker-input-error-container">
+                <Tooltip
+                    content={this.props.errorMessage}
+                    className="tooltip-error"
+                    showTooltip={this.state.isFocused}
+                    directionalHint={DirectionalHint.bottomLeftEdge}>
+                    <div className="people-picker-input-error-content">
+                        <input
+                            type={'text'}
+                            ref={(c): HTMLInputElement => this._field = c}
+                            value={this.state.value}
+                            onBlur={this._onBlur}
+                            onFocus={this._onFocus}
+                            onChange={this._onInputChange}
+                            className="people-picker-input-error"
+                            placeholder={this.props.placeholder}
+                        />
+                        <span className="people-picker-error-icon">
+                            <Icon iconName={'icon-warning2'}></Icon>
+                        </span>
+                    </div>
+                </Tooltip>
+            </div>
         );
     }
 
@@ -122,7 +145,6 @@ export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeopl
                 <div>
                     {this.state.selectedPrincipalList && this.state.selectedPrincipalList.map((principal, index) => (
                         <Principal
-                            iconName={this.props.iconName}
                             principal={principal}
                             isSelected={true}
                             onDelete={() => this._onSuggestionDelete(principal.id)}
@@ -135,7 +157,6 @@ export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeopl
                 <div className={peoplePickerSelectedClassName}>
                     {this.state.selectedPrincipalList && this.state.selectedPrincipalList.map((principal, index) => (
                         <Principal
-                            iconName={this.props.iconName}
                             principal={principal}
                             isSelected={true}
                             onDelete={() => this._onSuggestionDelete(principal.id)}
@@ -183,16 +204,12 @@ export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeopl
 
     @autobind
     private _onFocus(ev: React.FocusEvent<any>) {
-        this.setState({
-            isFocused: true
-        });
+        this.setState({ isFocused: true });
     }
 
     @autobind
     private _onBlur(ev: React.FocusEvent<any>) {
-        this.setState({
-            isFocused: false
-        });
+        this.setState({ isFocused: false });
     }
 
     public render() {

--- a/src/components/PeoplePicker/PeoplePicker.tsx
+++ b/src/components/PeoplePicker/PeoplePicker.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { IPeoplePickerProps } from './PeoplePicker.Props';
+import { getId } from '../../utilities/getId';
+import { autobind } from '../../utilities/autobind';
+import { CommonComponent } from '../Common/Common';
+import './PeoplePicker.scss';
+import { Search } from '../Search/Search';
+
+export interface IPeoplePickerState {
+    value?: string;
+    isFocused?: boolean;
+    errorMessage?: string;
+}
+
+export class PeoplePicker extends CommonComponent<IPeoplePickerProps, IPeoplePickerState> {
+    private _field;
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            value: props.value || props.defaultValue || '',
+            isFocused: false,
+            errorMessage: ''
+        };
+
+        this._onInputChange = this._onInputChange.bind(this);
+    }
+
+    private _onInputChange(event: React.ChangeEvent<any>): void {
+        const element: HTMLTextAreaElement = event.target as HTMLTextAreaElement;
+        const value: string = element.value;
+
+        this.setState({
+            value: value,
+            errorMessage: ''
+        } as IPeoplePickerState);
+
+        console.log(value);
+    }
+
+    public render() {
+        return (
+            <div className="people-picker-container">
+                <input
+                    type={'text'}
+                    ref={(c): HTMLInputElement => this._field = c}
+                    value={this.state.value}
+                    onChange={this._onInputChange}
+                    className="people-picker-input"
+                />
+            </div>
+        );
+    }
+}

--- a/src/components/PeoplePicker/PeoplePicker.tsx
+++ b/src/components/PeoplePicker/PeoplePicker.tsx
@@ -76,7 +76,8 @@ export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeopl
         }
     }
 
-    @autobind _ref(value: HTMLInputElement) {
+    @autobind
+    private _ref(value: HTMLInputElement) {
         this._field = value;
     }
 

--- a/src/components/PeoplePicker/PeoplePicker.tsx
+++ b/src/components/PeoplePicker/PeoplePicker.tsx
@@ -142,28 +142,24 @@ export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeopl
             [this.props.className]
         );
 
+        let selectedPrincipalList = this.state.selectedPrincipalList.map((principal, index) => (
+            <Principal
+                principal={principal}
+                isSelected={true}
+                onDelete={this._onSuggestionDelete}
+            />
+        ));
+
         if (this.props.singleSelect) {
             return (
                 <div>
-                    {this.state.selectedPrincipalList && this.state.selectedPrincipalList.map((principal, index) => (
-                        <Principal
-                            principal={principal}
-                            isSelected={true}
-                            onDelete={this._onSuggestionDelete}
-                        />
-                    ))}
+                    {this.state.selectedPrincipalList && selectedPrincipalList}
                 </div>
             );
         } else {
             return (
                 <div className={peoplePickerSelectedClassName}>
-                    {this.state.selectedPrincipalList && this.state.selectedPrincipalList.map((principal, index) => (
-                        <Principal
-                            principal={principal}
-                            isSelected={true}
-                            onDelete={this._onSuggestionDelete}
-                        />
-                    ))}
+                    {this.state.selectedPrincipalList && selectedPrincipalList}
                     <input
                         type={'text'}
                         ref={this._ref}

--- a/src/components/PeoplePicker/Principal.Props.ts
+++ b/src/components/PeoplePicker/Principal.Props.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { Principal } from './Principal';
+
+export interface IPrincipalProps extends React.Props<Principal> {
+    principal?: IPrincipal;
+    iconName?: string;
+    isSelected?: boolean;
+    onSelect?(principal: IPrincipal): void;
+    onDelete?(principal: IPrincipal): void;
+}
+
+export interface IPrincipal {
+    id: number;
+    displayName: string;
+    email: string;
+}

--- a/src/components/PeoplePicker/Principal.Props.ts
+++ b/src/components/PeoplePicker/Principal.Props.ts
@@ -3,7 +3,6 @@ import { Principal } from './Principal';
 
 export interface IPrincipalProps extends React.Props<Principal> {
     principal?: IPrincipal;
-    iconName?: string;
     isSelected?: boolean;
     onSelect?(principal: IPrincipal): void;
     onDelete?(principal: IPrincipal): void;
@@ -13,4 +12,12 @@ export interface IPrincipal {
     id: number;
     displayName: string;
     email: string;
+    type: PrincipalType;
+}
+
+export enum PrincipalType {
+    user = 0,
+    securityGroup = 1,
+    sharePointGroup = 2, 
+    activeDirectoryGroup = 3
 }

--- a/src/components/PeoplePicker/Principal.scss
+++ b/src/components/PeoplePicker/Principal.scss
@@ -1,0 +1,23 @@
+@import '../../index.scss';
+
+.principal-container
+{
+    padding: 5px 0px 5px 10px;
+
+    &:hover {
+        background-color: $primary-background-hover-color;
+        border-radius: 8px;
+        cursor: pointer;
+    }
+
+    .principal-delete-icon {
+        padding: 5px 5px 5px 5px;
+
+        &:hover {
+            cursor: pointer;
+            background-color: $primary-background-hover-color;
+            border-radius: 10px;
+        }        
+    }
+
+}

--- a/src/components/PeoplePicker/Principal.scss
+++ b/src/components/PeoplePicker/Principal.scss
@@ -25,14 +25,14 @@
     }
 
     .principal-security-group-icon {
-        color: green;
+        color: $success-color;
     }
 
     .principal-share-point-group-icon {
-        color: red;
+        color: $error-color;
     }
 
     .principal-active-directory-group-icon {
-        color: green;
+        color: $success-color;
     }
 }

--- a/src/components/PeoplePicker/Principal.scss
+++ b/src/components/PeoplePicker/Principal.scss
@@ -20,4 +20,19 @@
         }        
     }
 
+    .principal-user-icon {
+        color: $primary-color;
+    }
+
+    .principal-security-group-icon {
+        color: green;
+    }
+
+    .principal-share-point-group-icon {
+        color: red;
+    }
+
+    .principal-active-directory-group-icon {
+        color: green;
+    }
 }

--- a/src/components/PeoplePicker/Principal.tsx
+++ b/src/components/PeoplePicker/Principal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
-import { IPrincipalProps, IPrincipal } from './Principal.Props';
+import { IPrincipalProps, IPrincipal, PrincipalType } from './Principal.Props';
 import { getId } from '../../utilities/getId';
 import { autobind } from '../../utilities/autobind';
 import './Principal.scss';
@@ -39,26 +39,48 @@ export class Principal extends React.PureComponent<IPrincipalProps, IPrincipalSt
         this.setState({ showTooltip: false });
     }
 
+    @autobind
+    private _rednerTypeIcon(): JSX.Element {
+        if (this.props.principal.type === PrincipalType.user) {
+            return (
+                <Icon iconName={'icon-user'} className="principal-user-icon"></Icon>
+            );
+        } else if (this.props.principal.type === PrincipalType.securityGroup) {
+            return (
+                <Icon iconName={'icon-group'} className="principal-security-group-icon"></Icon>
+            );
+        } else if (this.props.principal.type === PrincipalType.sharePointGroup) {
+            return (
+                <Icon iconName={'icon-group'} className="principal-share-point-group-icon"></Icon>
+            );
+        } else if (this.props.principal.type === PrincipalType.activeDirectoryGroup) {
+            return (
+                <Icon iconName={'icon-group'} className="principal-active-directory-group-icon"></Icon>
+            );
+        }
+    }
+
     public render() {
+
         return (
             <span className="principal-container">
-                <Icon iconName={this.props.iconName}></Icon>
-                <span 
-                    onClick={() => this._onClickPrincipal()} 
+                {this._rednerTypeIcon()}
+                <span
+                    onClick={() => this._onClickPrincipal()}
                     onMouseOver={() => this._onMouseOver()}
                     onMouseOut={() => this._onMouseOut()}
                 >
-                {this.props.principal.displayName}
+                    {this.props.principal.displayName}
                 </span>
-                {this.props.isSelected && 
+                {this.props.isSelected &&
                     <Icon iconName={'icon-delete'} className="principal-delete-icon" onClick={() => this._onClickDelete()}></Icon>
                 }
                 <Tooltip
-                    className={'tooltip-white'}                                         
+                    className={'tooltip-white'}
                     content={this.props.principal.email}
                     directionalHint={DirectionalHint.rightCenter}
-                    showTooltip={this.state.showTooltip} 
-               />
+                    showTooltip={this.state.showTooltip}
+                />
             </span>
         );
     }

--- a/src/components/PeoplePicker/Principal.tsx
+++ b/src/components/PeoplePicker/Principal.tsx
@@ -21,10 +21,12 @@ export class Principal extends React.PureComponent<IPrincipalProps, IPrincipalSt
         };
     }
 
+    @autobind
     private _onClickPrincipal(): void {
         this.props.onSelect(this.props.principal);
     }
 
+    @autobind
     private _onClickDelete(): void {
         this.props.onDelete(this.props.principal);
     }
@@ -43,19 +45,19 @@ export class Principal extends React.PureComponent<IPrincipalProps, IPrincipalSt
     private _rednerTypeIcon(): JSX.Element {
         if (this.props.principal.type === PrincipalType.user) {
             return (
-                <Icon iconName={'icon-user'} className="principal-user-icon"></Icon>
+                <Icon iconName="icon-user"  className="principal-user-icon"></Icon>
             );
         } else if (this.props.principal.type === PrincipalType.securityGroup) {
             return (
-                <Icon iconName={'icon-group'} className="principal-security-group-icon"></Icon>
+                <Icon iconName="icon-group"  className="principal-security-group-icon"></Icon>
             );
         } else if (this.props.principal.type === PrincipalType.sharePointGroup) {
             return (
-                <Icon iconName={'icon-group'} className="principal-share-point-group-icon"></Icon>
+                <Icon iconName="icon-group"  className="principal-share-point-group-icon"></Icon>
             );
         } else if (this.props.principal.type === PrincipalType.activeDirectoryGroup) {
             return (
-                <Icon iconName={'icon-group'} className="principal-active-directory-group-icon"></Icon>
+                <Icon iconName="icon-group" className="principal-active-directory-group-icon"></Icon>
             );
         }
     }
@@ -66,17 +68,21 @@ export class Principal extends React.PureComponent<IPrincipalProps, IPrincipalSt
             <span className="principal-container">
                 {this._rednerTypeIcon()}
                 <span
-                    onClick={() => this._onClickPrincipal()}
-                    onMouseOver={() => this._onMouseOver()}
-                    onMouseOut={() => this._onMouseOut()}
+                    onClick={this._onClickPrincipal}
+                    onMouseOver={this._onMouseOver}
+                    onMouseOut={this._onMouseOut}
                 >
                     {this.props.principal.displayName}
                 </span>
                 {this.props.isSelected &&
-                    <Icon iconName={'icon-delete'} className="principal-delete-icon" onClick={() => this._onClickDelete()}></Icon>
+                    <Icon
+                        iconName="icon-delete"
+                        className="principal-delete-icon"
+                        onClick={this._onClickDelete}
+                    />
                 }
                 <Tooltip
-                    className={'tooltip-white'}
+                    className="tooltip-white"
                     content={this.props.principal.email}
                     directionalHint={DirectionalHint.rightCenter}
                     showTooltip={this.state.showTooltip}

--- a/src/components/PeoplePicker/Principal.tsx
+++ b/src/components/PeoplePicker/Principal.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import * as classNames from 'classnames';
+import { IPrincipalProps, IPrincipal } from './Principal.Props';
+import { getId } from '../../utilities/getId';
+import { autobind } from '../../utilities/autobind';
+import './Principal.scss';
+import { Icon } from './../../../src/components/Icon/Icon';
+import { Tooltip } from '../Tooltip/Tooltip';
+import { DirectionalHint } from '../../utilities/DirectionalHint';
+
+export interface IPrincipalState {
+    showTooltip?: boolean;
+}
+
+export class Principal extends React.PureComponent<IPrincipalProps, IPrincipalState> {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showTooltip: false
+        };
+    }
+
+    private _onClickPrincipal(): void {
+        this.props.onSelect(this.props.principal);
+    }
+
+    private _onClickDelete(): void {
+        this.props.onDelete(this.props.principal);
+    }
+
+    @autobind
+    private _onMouseOver(): void {
+        this.setState({ showTooltip: true });
+    }
+
+    @autobind
+    private _onMouseOut(): void {
+        this.setState({ showTooltip: false });
+    }
+
+    public render() {
+        return (
+            <span className="principal-container">
+                <Icon iconName={this.props.iconName}></Icon>
+                <span 
+                    onClick={() => this._onClickPrincipal()} 
+                    onMouseOver={() => this._onMouseOver()}
+                    onMouseOut={() => this._onMouseOut()}
+                >
+                {this.props.principal.displayName}
+                </span>
+                {this.props.isSelected && 
+                    <Icon iconName={'icon-delete'} className="principal-delete-icon" onClick={() => this._onClickDelete()}></Icon>
+                }
+                <Tooltip
+                    className={'tooltip-white'}                                         
+                    content={this.props.principal.email}
+                    directionalHint={DirectionalHint.rightCenter}
+                    showTooltip={this.state.showTooltip} 
+               />
+            </span>
+        );
+    }
+}

--- a/src/components/PeoplePicker/Principal.tsx
+++ b/src/components/PeoplePicker/Principal.tsx
@@ -43,34 +43,27 @@ export class Principal extends React.PureComponent<IPrincipalProps, IPrincipalSt
 
     @autobind
     private _getIconDetails() {
-        if (this.props.principal.type === PrincipalType.user) {
-            return (
-                {
+        switch (this.props.principal.type) {
+            case PrincipalType.user:
+                return {
                     iconName: 'icon-user',
                     className: 'principal-user-icon'
-                }
-            );
-        } else if (this.props.principal.type === PrincipalType.securityGroup) {
-            return (
-                {
+                };
+            case PrincipalType.securityGroup:
+                return {
                     iconName: 'icon-group',
                     className: 'principal-security-group-icon'
-                }
-            );
-        } else if (this.props.principal.type === PrincipalType.sharePointGroup) {
-            return (
-                {
+                };
+            case PrincipalType.sharePointGroup:
+                return {
                     iconName: 'icon-group',
                     className: 'principal-share-point-group-icon'
-                }
-            );
-        } else if (this.props.principal.type === PrincipalType.activeDirectoryGroup) {
-            return (
-                {
+                };
+            case PrincipalType.activeDirectoryGroup:
+                return {
                     iconName: 'icon-group',
                     className: 'principal-active-directory-group-icon'
-                }
-            );
+                };
         }
     }
 

--- a/src/components/PeoplePicker/Principal.tsx
+++ b/src/components/PeoplePicker/Principal.tsx
@@ -42,31 +42,49 @@ export class Principal extends React.PureComponent<IPrincipalProps, IPrincipalSt
     }
 
     @autobind
-    private _rednerTypeIcon(): JSX.Element {
+    private _getIconDetails() {
         if (this.props.principal.type === PrincipalType.user) {
             return (
-                <Icon iconName="icon-user"  className="principal-user-icon"></Icon>
+                {
+                    iconName: 'icon-user',
+                    className: 'principal-user-icon'
+                }
             );
         } else if (this.props.principal.type === PrincipalType.securityGroup) {
             return (
-                <Icon iconName="icon-group"  className="principal-security-group-icon"></Icon>
+                {
+                    iconName: 'icon-group',
+                    className: 'principal-security-group-icon'
+                }
             );
         } else if (this.props.principal.type === PrincipalType.sharePointGroup) {
             return (
-                <Icon iconName="icon-group"  className="principal-share-point-group-icon"></Icon>
+                {
+                    iconName: 'icon-group',
+                    className: 'principal-share-point-group-icon'
+                }
             );
         } else if (this.props.principal.type === PrincipalType.activeDirectoryGroup) {
             return (
-                <Icon iconName="icon-group" className="principal-active-directory-group-icon"></Icon>
+                {
+                    iconName: 'icon-group',
+                    className: 'principal-active-directory-group-icon'
+                }
             );
         }
     }
 
     public render() {
+        let iconDetails: {
+            iconName: string,
+            className: string
+        };
+
+        iconDetails = this._getIconDetails();
 
         return (
             <span className="principal-container">
-                {this._rednerTypeIcon()}
+                <Icon iconName={iconDetails.iconName} className={iconDetails.className} ></Icon>
                 <span
                     onClick={this._onClickPrincipal}
                     onMouseOver={this._onMouseOver}

--- a/src/components/PeoplePicker/index.ts
+++ b/src/components/PeoplePicker/index.ts
@@ -1,0 +1,2 @@
+export * from './PeoplePicker';
+export * from './PeoplePicker.Props';

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export * from './components/LeftNavigation';
 export * from './components/MainNavigation';
 export * from './components/MessageBar';
 export * from './components/Overlay';
+export * from './components/PeoplePicker';
 export * from './components/Pivot';
 export * from './components/Popup';
 export * from './components/Search';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,6 +51,7 @@ module.exports = {
         MessageBox: "./examples/src/MessageBox.tsx",
         Compare: "./examples/src/Compare.tsx",
         Scheduler: "./examples/src/Scheduler.tsx",
+        PeoplePicker: "./examples/src/PeoplePicker.tsx"
     },
     output: {
         path: path.join(__dirname, '/dist'),


### PR DESCRIPTION
The PeoplePicker component is used to select users, AD groups, Security groups and SharePoint groups. The user writes the text in the search box and after 3 letters retrieves the data from the backend and List is shown in dropdown.

- http://take.ms/DXTLN
- In PeoplePicker.Props are defined properties
- You can use singleSelect prop to put limit on one selected principal. By default you can select multiple principals
- If it's not disabled you need to define onSearch and onSelect methods