### PR TITLE
Refactor/async tree load

### DIFF
--- a/examples/MockData/treeFilterElements.ts
+++ b/examples/MockData/treeFilterElements.ts
@@ -54,15 +54,13 @@ export function createRandomizedData(numOfItems, maxDepth) {
     return data;
 }
 
-export function createAsyncLoadRandomizedData(numOfItems, maxDepth) {
-    let asynclyLoadableIds = [];
+export function createAsyncLoadRandomizedData(numOfItems, maxDepth) {    
     const createRandomizedItem = (key, depth) => {
         let children = [];
         let hasChildren;
         let name = RANDOM_WORDS[Math.floor(Math.random() * RANDOM_WORDS.length)];
-        if (Math.random() > 0.5) {
+        if (Math.random() > 0.3) {
             hasChildren = true;
-            asynclyLoadableIds.push(key);
         } else {
             let numChildren = depth < maxDepth ? 4 : 0;
             for (let i = 0; i < numChildren; i++) {
@@ -84,6 +82,6 @@ export function createAsyncLoadRandomizedData(numOfItems, maxDepth) {
     for (let i = 0; i < numOfItems; i++) {
         data.push(createRandomizedItem(i, 0));
     }
-    return [data, asynclyLoadableIds];
+    return data;
 
 }

--- a/examples/pages/TreeFilter.html
+++ b/examples/pages/TreeFilter.html
@@ -19,17 +19,4 @@
   .color {
     color: #7DC458;
   }
-
-  .item-container.loading-container {
-    display: flex;
-    align-items: center;
-  }
-
-  .spinner.tree-view-async-loading-spinner>.spinner-circle {
-    margin: 0;
-  }
-
-  .tree-view-async-loading-label {
-    margin-left: 6px;
-  }
 </style>

--- a/examples/src/TreeFilter.tsx
+++ b/examples/src/TreeFilter.tsx
@@ -2,7 +2,7 @@
 import 'babel-polyfill';
 import 'ts-helpers';
 
-import { rebuildTree, updateTree, expandOrCollapseTreeItem } from '../../src/utilities/rebuildTree';
+import { rebuildTree, updateTree, expandOrCollapseTreeItem, expandOrCollapseAsyncTreeItem } from '../../src/utilities/rebuildTree';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { TreeFilter, IFilterSelection, FilterSelectionEnum, VirtualizedTreeView, TreeItem } from '../../src/components/TreeFilter';
@@ -13,8 +13,7 @@ import { Spinner } from '../../src/components/Spinner/Spinner';
 import { SpinnerType } from '../../src/components/Spinner';
 
 interface DemoState {
-    filterStates: { [id: string]: IFilterSelection };
-    asynclyLoadableItemIds: string[];
+    filterStates: { [id: string]: IFilterSelection };    
     asyncTreeData: TreeItem[];
     treeData: TreeItem[];
 }
@@ -28,9 +27,8 @@ export class Index extends React.Component<any, DemoState> {
         super(props);
         const asyncTreeData = createAsyncLoadRandomizedData(1000, 4);
         this.state = {
-            filterStates: {},
-            asynclyLoadableItemIds: asyncTreeData[1],
-            asyncTreeData: asyncTreeData[0],
+            filterStates: {},            
+            asyncTreeData: asyncTreeData,
             treeData: createRandomizedData(2000, 2)
         };
     }
@@ -49,54 +47,40 @@ export class Index extends React.Component<any, DemoState> {
         console.log('Save clicked!', newFilters);
     }
 
-    onAsyncTreeItemExpand = (treeItem: TreeItem, lookupTableGetter) => {
+    onAsyncTreeItemExpand = (treeItem: TreeItem, lookupTableGetter) => {        
+        
+        
 
-        const index = this.state.asynclyLoadableItemIds.indexOf(treeItem.id);
-        const isAsyncLoadItem = index > -1;
-        const isNowExpanded = !treeItem.expanded;
-        let expandedTreeItem = {
-            ...treeItem,
-            expanded: !treeItem.expanded,
-            asyncChildrenLoadInProgress: treeItem.hasChildren && treeItem.children.length === 0
-        };
-
-        let newAsynclyLoadableItems = [...this.state.asynclyLoadableItemIds];
-        if (isAsyncLoadItem) {
-            newAsynclyLoadableItems.splice(index, 1);            
-        }
-
-        this.setState({
-            ...this.state,
-            asyncTreeData: updateTree(this.state.asyncTreeData, expandedTreeItem, lookupTableGetter),
-            asynclyLoadableItemIds: newAsynclyLoadableItems
-        });
-
-        if (!isAsyncLoadItem || !isNowExpanded) {
-            return;
-        }
-        setTimeout(() => {
-            const randomNumber = (Math.random() * 100).toFixed(0);
-            const newTreeItem = {
-                ...treeItem,
-                expanded: !treeItem.expanded,
-                asyncChildrenLoadInProgress: false,
-                children: [{
-                    id: treeItem.id + '-' + '1',
-                    value: 'asyncly loaded ' + randomNumber,
-                    expanded: false
-                }, {
-                    id: treeItem.id + '-' + '2',
-                    value: 'asyncly loaded 2',
-                    expanded: false
-                }]
-            };
-
-            const newTreeData = updateTree(this.state.asyncTreeData, newTreeItem, lookupTableGetter);
+        expandOrCollapseAsyncTreeItem(() => this.state.asyncTreeData,
+         treeItem,
+          lookupTableGetter, 
+          (roots) => {
             this.setState({
                 ...this.state,
-                asyncTreeData: newTreeData
+                asyncTreeData: roots
             });
-        }, 4500);
+
+         },
+        
+          () => {
+             return new Promise<TreeItem[]>((resolve) => {
+                setTimeout(() => {
+                    const randomNumber = (Math.random() * 100).toFixed(0);                    
+                    const children = [{
+                        id: treeItem.id + '-' + '1',
+                        value: 'asyncly loaded ' + randomNumber,
+                        expanded: false
+                    }, {
+                        id: treeItem.id + '-' + '2',
+                        value: 'asyncly loaded 2',
+                        expanded: false
+                    }];
+
+                    resolve(children);                            
+                }, 3000);
+             });
+          }
+        );        
     }
 
     private onItemExpand = (treeItem: TreeItem, lookupTableGetter) => {

--- a/examples/src/TreeFilter.tsx
+++ b/examples/src/TreeFilter.tsx
@@ -56,22 +56,13 @@ export class Index extends React.Component<any, DemoState> {
         const isNowExpanded = !treeItem.expanded;
         let expandedTreeItem = {
             ...treeItem,
-            expanded: !treeItem.expanded
+            expanded: !treeItem.expanded,
+            asyncChildrenLoadInProgress: treeItem.hasChildren && treeItem.children.length === 0
         };
 
         let newAsynclyLoadableItems = [...this.state.asynclyLoadableItemIds];
         if (isAsyncLoadItem) {
-            newAsynclyLoadableItems.splice(index, 1);
-
-            let loadingLabelTreeItem = {
-                id: treeItem.id + '-1'  ,
-                value: 'Loading...',
-                expanded: false,
-                children: [],
-                renderElement: this.renderLoadingLabel
-            };
-
-            expandedTreeItem.children = [loadingLabelTreeItem];
+            newAsynclyLoadableItems.splice(index, 1);            
         }
 
         this.setState({
@@ -88,6 +79,7 @@ export class Index extends React.Component<any, DemoState> {
             const newTreeItem = {
                 ...treeItem,
                 expanded: !treeItem.expanded,
+                asyncChildrenLoadInProgress: false,
                 children: [{
                     id: treeItem.id + '-' + '1',
                     value: 'asyncly loaded ' + randomNumber,
@@ -104,24 +96,7 @@ export class Index extends React.Component<any, DemoState> {
                 ...this.state,
                 asyncTreeData: newTreeData
             });
-        }, 1500);
-    }
-
-    private renderLoadingLabel(itemKey: string, style: any): JSX.Element {
-        return (
-            <div
-                key={itemKey}
-                className="item-container loading-container"
-                style={style}
-            >
-                <Spinner className="tree-view-async-loading-spinner"
-                    type={SpinnerType.small}
-                />
-                <span className="tree-view-async-loading-label">
-                    Loading...
-                </span>
-            </div>
-        );
+        }, 4500);
     }
 
     private onItemExpand = (treeItem: TreeItem, lookupTableGetter) => {

--- a/src/components/TreeFilter/TreeFilter.Props.ts
+++ b/src/components/TreeFilter/TreeFilter.Props.ts
@@ -108,4 +108,5 @@ export interface TreeItem {
     hasChildren?: boolean;
     hoverOverBtn?: Array<IHoverOverBtn>;
     renderElement?: (itemKey: string, style: any) => JSX.Element;
+    asyncChildrenLoadInProgress?: boolean;
 }

--- a/src/components/TreeFilter/TreeFilter.scss
+++ b/src/components/TreeFilter/TreeFilter.scss
@@ -1,5 +1,10 @@
 @import '../../index.scss';
 
+.tree-filter-callout {
+    margin-top: 4px;
+
+}
+
 .tree-filter-container {
     user-select: none;
     width: 200px;

--- a/src/components/TreeFilter/VirtualizedTreeView.scss
+++ b/src/components/TreeFilter/VirtualizedTreeView.scss
@@ -32,10 +32,12 @@
             }
             
             &.loading-container {
-                display: flex;
-                align-items: center;
+                display: flex;                
     
-               
+                .spinner.tree-view-async-loading-spinner>.spinner-circle {
+                    margin: 0;
+                  }
+                
                 .tree-view-async-loading-label {
                     margin-left: 6px;
                   }
@@ -92,6 +94,10 @@
                     text-overflow: ellipsis;
                     width: 95%;
                     position: relative;
+                }
+
+                &.loading-container {
+                    padding-left: 12px;
                 }
             }
 

--- a/src/components/TreeFilter/VirtualizedTreeView.scss
+++ b/src/components/TreeFilter/VirtualizedTreeView.scss
@@ -1,7 +1,5 @@
 @import '../../index.scss';
 
-.tree-filter-callout {
-    margin-top: 4px;
 
     .virtualized-tree-filter-container {
         padding: 6px;
@@ -32,6 +30,16 @@
                 margin-right: 6px;
                 font-size: 12px;
             }
+            
+            &.loading-container {
+                display: flex;
+                align-items: center;
+    
+               
+                .tree-view-async-loading-label {
+                    margin-left: 6px;
+                  }
+              }
         }
 
         .virtualized-tree-filter-footer-count {
@@ -98,4 +106,3 @@
             }
         }
     }
-}

--- a/src/components/TreeFilter/VirtualizedTreeView.scss
+++ b/src/components/TreeFilter/VirtualizedTreeView.scss
@@ -83,7 +83,7 @@
             .item-container {
                 .virtualized-tree-expand-icon {
                     position: relative;
-                    top: -3px;
+                    top: -4px;
                     margin-right: 2px;
                 }
 

--- a/src/components/TreeFilter/VirtualizedTreeView.tsx
+++ b/src/components/TreeFilter/VirtualizedTreeView.tsx
@@ -182,7 +182,12 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
         }
         const onExpandClick = (event) => {
             event.stopPropagation();
-            this.props.onItemExpand(treeItem, this.props.lookupTableGetter);
+            if (this.props.onItemExpand) {
+                this.props.onItemExpand(treeItem, this.props.lookupTableGetter);
+            } else {
+                treeItem.expanded = !treeItem.expanded;
+                this._list.recomputeRowHeights();
+            }
         };
 
         const filterSelection = this.props.filterSelection;
@@ -209,10 +214,10 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
                 treeItem.iconClassName
             );
 
-            let {id, hoverOverBtn} = treeItem;
+            let { id, hoverOverBtn } = treeItem;
 
             if (this.props.isSingleSelect) {
-                const SingleSelectItem = ({}) => 
+                const SingleSelectItem = ({ }) =>
                     <span
                         className="virtualized-tree-single-select-item"
                         onClick={onSingleSelectItemClick}
@@ -222,7 +227,7 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
                         }
                         {treeItem.value}
                     </span>;
-                const SingleSelectItemWithButtons = addHoverableButtons({id, hoverOverBtn})(SingleSelectItem);
+                const SingleSelectItemWithButtons = addHoverableButtons({ id, hoverOverBtn })(SingleSelectItem);
 
                 return <SingleSelectItemWithButtons />;
             } else {
@@ -231,7 +236,7 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
                     checked = CheckStatus.ChildChecked;
                 }
 
-                const ItemWithButtons = addHoverableButtons({id, hoverOverBtn})(VirtualizedTreeViewCheckBox);
+                const ItemWithButtons = addHoverableButtons({ id, hoverOverBtn })(VirtualizedTreeViewCheckBox);
                 return (
                     <ItemWithButtons
                         itemId={treeItem.id}
@@ -263,11 +268,11 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
                             </li>
                         </ul>
                     }
-                    { 
+                    {
                         treeItem.asyncChildrenLoadInProgress &&
                         <ul>
                             <li>
-                                {                                    
+                                {
                                     this.renderAsyncLoadingNode(itemKey)
                                 }
                             </li>
@@ -292,26 +297,26 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
         }
     }
 
-    private renderAsyncLoadingNode(loadingTreeNodeKey) { 
+    private renderAsyncLoadingNode(loadingTreeNodeKey) {
         const style = {
             height: this.props.rowHeight,
             marginLeft: this.props.isSingleSelect ? 6 : 18
         };
-            return (
-                <div
-                    key={loadingTreeNodeKey + '_Loading'}
-                    className="item-container loading-container"
-                    style={style}
-                >
-                    <Spinner className="tree-view-async-loading-spinner"
-                        type={SpinnerType.small}
-                    />
-                    <span className="tree-view-async-loading-label">
-                        Loading...
+        return (
+            <div
+                key={loadingTreeNodeKey + '_Loading'}
+                className="item-container loading-container"
+                style={style}
+            >
+                <Spinner className="tree-view-async-loading-spinner"
+                    type={SpinnerType.small}
+                />
+                <span className="tree-view-async-loading-label">
+                    Loading...
                     </span>
-                </div>
-            );
-        }
+            </div>
+        );
+    }
 
     private isItemInList(list, treeItem: TreeItem): boolean {
         return list.indexOf(treeItem.id) !== -1;

--- a/src/components/TreeFilter/VirtualizedTreeView.tsx
+++ b/src/components/TreeFilter/VirtualizedTreeView.tsx
@@ -293,10 +293,15 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
     }
 
     private renderAsyncLoadingNode(loadingTreeNodeKey) { 
+        const style = {
+            height: this.props.rowHeight,
+            marginLeft: 4
+        };
             return (
                 <div
                     key={loadingTreeNodeKey + '_Loading'}
                     className="item-container loading-container"
+                    style={style}
                 >
                     <Spinner className="tree-view-async-loading-spinner"
                         type={SpinnerType.small}

--- a/src/components/TreeFilter/VirtualizedTreeView.tsx
+++ b/src/components/TreeFilter/VirtualizedTreeView.tsx
@@ -295,7 +295,7 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
     private renderAsyncLoadingNode(loadingTreeNodeKey) { 
         const style = {
             height: this.props.rowHeight,
-            marginLeft: 4
+            marginLeft: this.props.isSingleSelect ? 6 : 18
         };
             return (
                 <div

--- a/src/components/TreeFilter/VirtualizedTreeView.tsx
+++ b/src/components/TreeFilter/VirtualizedTreeView.tsx
@@ -263,6 +263,16 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
                             </li>
                         </ul>
                     }
+                    { 
+                        treeItem.asyncChildrenLoadInProgress &&
+                        <ul>
+                            <li>
+                                {                                    
+                                    this.renderAsyncLoadingNode(itemKey)
+                                }
+                            </li>
+                        </ul>
+                    }
                 </div>
             );
         } else if (itemHasChildren(treeItem) || treeItem.hasChildren) { // expandable
@@ -282,6 +292,22 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
         }
     }
 
+    private renderAsyncLoadingNode(loadingTreeNodeKey) { 
+            return (
+                <div
+                    key={loadingTreeNodeKey + '_Loading'}
+                    className="item-container loading-container"
+                >
+                    <Spinner className="tree-view-async-loading-spinner"
+                        type={SpinnerType.small}
+                    />
+                    <span className="tree-view-async-loading-label">
+                        Loading...
+                    </span>
+                </div>
+            );
+        }
+
     private isItemInList(list, treeItem: TreeItem): boolean {
         return list.indexOf(treeItem.id) !== -1;
     }
@@ -290,12 +316,12 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
         return this.getExpandedItemCount(this.state.filteredItems[index]) * this.props.rowHeight;
     }
 
-    private getExpandedItemCount = (item) => {
+    private getExpandedItemCount = (item: TreeItem) => {
         let count = 1;
         if (item.expanded) {
             count += item.children
                 .map(this.getExpandedItemCount)
-                .reduce(function (total, currentCount) { return total + currentCount; }, 0);
+                .reduce(function (total, currentCount) { return total + currentCount; }, 0) + (item.asyncChildrenLoadInProgress ? 1 : 0);
         }
         return count;
     }


### PR DESCRIPTION
most of the implementation regarding the async loading feature was actually in the example and would have to be redone each time the feature was to be used. 

expandOrCollapseAsyncTreeItem is the new function that handles the tree reconstruction when items are requested.
```javascript
export function expandOrCollapseAsyncTreeItem(
getRoots: () => TreeItem[],
 treeItemToExpand: TreeItem, 
lookupTableGetter: () => TreeLookups,
 onTreeUpdated: (newRoots: TreeItem[]) => void,
 asyncItemsGetter: () => Promise<TreeItem[]>): void {
```
In the default case it behaves as a normal expand. But if the node has _hasChildren_ set to true and no children, then this signal a async load.

the tree roots are needed to reconstruct the tree as we want it to be immutable. Since we will be reconstructing it two times(start of the async action, end of the async action) we need to be able to get the latest values, hence the getRoots callback instead of the actual values.

lookupTableGetter, same deal as with tree roots.

Instead of returning the rebuilt tree we need to update it twice(start, end of action), so the onTreeUpdated callback was added.

asyncItemsGetter is the logic that actually retrieves the new data.

The reason for this convoluted logic is so that everything regarding the async load is limited to this component. Otherwise in every implementation we would have to watch out that we would need to trach which nodes are currently loading, which are loaded, etc.

Not entirely happy with this solution presented but i cannot for the life of me come up with anything better.

