### PR TITLE
Bug/tree ignore missing key

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -7,21 +7,21 @@ import './Icon.scss';
 
 export const Icon: (props: IIconProps) => JSX.Element = (props: IIconProps) => {
     const customIcon = props.iconName === '';
-    const svgIcon = props.iconName.startsWith('svg');
-    let iconPrefix = 'icon '.concat( svgIcon ? 'svg' : 'font');
+    const svgIcon = props.iconName && props.iconName.startsWith('svg');
+    let iconPrefix = 'icon '.concat(svgIcon ? 'svg' : 'font');
     let iconClassName = classNames(
         [iconPrefix], {
             [props.iconName]: !customIcon
         }, [props.className]);
 
-        if (svgIcon) {
-            return <svg className = {iconClassName} width = {props.width} height= {props.height}>
-            <use xlinkHref= {'#symbol-defs_' + props.iconName} />
+    if (svgIcon) {
+        return <svg className={iconClassName} width={props.width} height={props.height}>
+            <use xlinkHref={'#symbol-defs_' + props.iconName} />
         </svg>;
-        }else {
-            return <i { ...getNativeAttributes(props, htmlElementAttributes) } className={iconClassName} />;
-        }
+    } else {
+        return <i { ...getNativeAttributes(props, htmlElementAttributes) } className={iconClassName} />;
+    }
 
-    
+
 
 };

--- a/src/components/TreeFilter/TreeFilter.tsx
+++ b/src/components/TreeFilter/TreeFilter.tsx
@@ -61,7 +61,14 @@ export class TreeFilter extends React.PureComponent<ITreeFilterProps, ITreeFilte
             return { selectionText: this.props.emptySelectionText, titleText: this.props.emptySelectionText };
         }
 
-        const checkedItemIds = selection.selectedIDs;
+        const keys = Object.keys(itemLookup);
+        const checkedItemIds = selection.selectedIDs.filter(selectedId => {
+            if (itemLookup.hasOwnProperty(selectedId)) {
+                return selectedId;
+            } else {
+                console.warn(`Warning: Provided selected key: [${selectedId}] doesn't exist.`);
+            }
+        });
 
         if (checkedItemIds === undefined || checkedItemIds.length === 0) {
             selectionText = titleText = this.props.emptySelectionText;


### PR DESCRIPTION
If key provided in filterSelection doesn't exist warning will be displayed in console and that key ignored. Also fixed small bug on icon