### PR TITLE
Feat/cell formatter

### DIFF
--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -73,7 +73,7 @@ export interface GridColumn {
     minWidth?: number;
     fixedWidth?: boolean;
     dataMember?: string;
-    cellFormatter?: (cellData) => any;
+    cellFormatter?: (cellData, rowData) => any;
     cellClassName?: string;
     headerClassName?: string;
     headerTooltip?: string;

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -387,7 +387,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
 
         const columnElement = () => {
             if (column.cellFormatter) {
-                return column.cellFormatter(cellData);
+                return column.cellFormatter(cellData, rowData);
             } else {
                 return (
                     <div style={{ padding: '3px 5px 0 5px' }} >

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -145,7 +145,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
             { 'border-column-cell': notLastIndex },
             { 'is-selected': rowIndex === this.state.selectedRowIndex });
 
-        const columnElement = () => {            
+        const columnElement = () => {
             if (column.cellFormatter) {
                 return column.cellFormatter(cellData, rowData);
             } else {

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -145,9 +145,9 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
             { 'border-column-cell': notLastIndex },
             { 'is-selected': rowIndex === this.state.selectedRowIndex });
 
-        const columnElement = () => {
+        const columnElement = () => {            
             if (column.cellFormatter) {
-                return column.cellFormatter(cellData);
+                return column.cellFormatter(cellData, rowData);
             } else {
                 return (
                     <div style={{ padding: '3px 5px 0 5px' }} >


### PR DESCRIPTION
added row Data to the cellFormatter to enable custom rendering based on other column values. Without this there is a need to create new objects based on the actual input data. Even with reselect this would cause the whole grid to rerender and not just the new rows added if i am not mistaken, each row would always be a new object. In any case, this here i believe is the better solution to this problem. 

One thing that always bothered me was the name cellFormatter, but we always used it for rendering :D.
