### PR TITLE
Fix/svg icon size problems

### DIFF
--- a/examples/src/Button.tsx
+++ b/examples/src/Button.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 import { Button } from './../../src/components/Button/Button';
+import './../../src/components/Icon/symbol-defs.svg';
 
 export class Index extends React.Component<any, any> {
     public render() {

--- a/examples/src/Icon.tsx
+++ b/examples/src/Icon.tsx
@@ -168,8 +168,8 @@ export class Index extends React.Component<any, any> {
                 <div> <Icon iconName={'icon-warning'}></Icon> <span>   icon-warning</span></div>
                 <div> <Icon iconName={'icon-world'}></Icon> <span>   icon-world</span></div>
                 {symbols.map(i => {
-                    let iconName = i.id.substring(i.id.indexOf('_') + 1); 
-                    return <div> <Icon iconName={iconName} width={'16px'} height={'16px'}></Icon> <span>   {iconName}</span></div>;
+                    let iconName = i.id.substring(i.id.indexOf('_') + 1);
+                    return <div> <Icon iconName={iconName}></Icon> <span>   {iconName}</span></div>;
                 })}
             </div>
         );

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -19,8 +19,8 @@ $button-height: 32px;
 
     &:focus {
         outline: none;
-    }
-
+    }    
+    
     &:disabled {
         cursor: default;
     }
@@ -33,7 +33,11 @@ $button-height: 32px;
             font-size: 16px;
             margin-right: 8px;
             position: relative;
-            top: 1px;
+            top: 1px;      
+            
+            &.svg {                
+                fill: $white-color !important;                
+            }
         }
     }
 
@@ -44,6 +48,10 @@ $button-height: 32px;
             margin-right: 0;
             color: $white-color;
             font-size: 16px;
+
+            &.svg {                
+                fill: $white-color !important;
+            }
         }
     }
 
@@ -93,6 +101,10 @@ $button-height: 32px;
         &.button-icon-text {
             .icon {
                 color: $primary-color;
+
+                &.svg {
+                    fill: $primary-color !important;
+                }
             }
         }
 
@@ -101,6 +113,10 @@ $button-height: 32px;
 
             .icon {
                 color: $primary-color;
+
+                &.svg {
+                    fill: $primary-color !important;
+                }
             }
         }
 			
@@ -111,6 +127,10 @@ $button-height: 32px;
 
             .button-label, .icon {
                 color: $primary-hover-color;
+            }
+
+            >.icon.svg {
+                fill: $primary-hover-color !important;
             }
         }
 
@@ -124,6 +144,10 @@ $button-height: 32px;
             .button-label, .icon {
                 color: $primary-disabled-color;
             }
+
+            &.icon.svg {
+                fill: $primary-disabled-color !important;
+            }
         }
     }
 
@@ -135,6 +159,9 @@ $button-height: 32px;
         &.button-icon-text {
             .icon {
                 color: $tertiary-color;
+                &.svg {
+                    fill: $tertiary-color !important;
+                }
             }
         }
 
@@ -143,6 +170,10 @@ $button-height: 32px;
 
             .icon {
                 color: $tertiary-color;
+
+                &.svg {
+                    fill: $tertiary-color !important;
+                }
             }
         }
 
@@ -153,6 +184,10 @@ $button-height: 32px;
 
             .button-label, .icon {
                 color: $tertiary-hover-color;
+            }
+
+            >.icon.svg {
+                fill: $tertiary-hover-color !important;
             }
         }
         
@@ -165,6 +200,10 @@ $button-height: 32px;
 
             .button-label, .icon {
                 color: $tertiary-disabled-color;
+            }
+
+            >.icon.svg {
+                fill: $tertiary-disabled-color !important;
             }
         }
     }
@@ -194,6 +233,10 @@ $button-height: 32px;
         &.button-icon-text {
             .icon {
                 color: $primary-color;
+
+                &.svg {
+                    fill: $primary-color !important;
+                }
             }
         }
 			
@@ -202,6 +245,10 @@ $button-height: 32px;
 		&:active {
             .button-label, .icon {
                 color: $primary-hover-color;
+            }
+
+            >.icon.svg {
+                fill: $primary-hover-color !important;
             }
         }
         
@@ -212,6 +259,10 @@ $button-height: 32px;
         &:disabled {
             .button-label, .icon {
                 color: $secondary-disabled-color;
+            }
+
+            >.icon.svg {
+                fill: $primary-disabled-color !important;
             }
         }
     }
@@ -245,10 +296,18 @@ $button-height: 32px;
     .icon {
         color: $link-color;
 
+        &.svg {
+            fill: $link-color !important;
+        }
+
         &:hover,
         &:focus,
         &:active {
             color: $link-hover-color;
+
+            &.svg {
+                fill: $link-hover-color !important;
+            }
         }
     }
 
@@ -263,6 +322,10 @@ $button-height: 32px;
 
         .icon {
             color: $secondary-disabled-color;
+
+            &.svg {
+                fill: $secondary-disabled-color !important;
+            }
         }
     }
 }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -19,8 +19,8 @@ $button-height: 32px;
 
     &:focus {
         outline: none;
-    }    
-    
+    }
+
     &:disabled {
         cursor: default;
     }

--- a/src/components/Icon/Icon.Props.ts
+++ b/src/components/Icon/Icon.Props.ts
@@ -3,6 +3,14 @@ import * as React from 'react';
 export interface IIconProps extends React.HTMLProps<HTMLElement> {
   iconName?: string;
   className?: string;
+  iconSize?: IconSize;
   width?: any;
   height?: any;
+}
+
+export enum IconSize {
+  smallest = 'smallest',
+  small = 'small',
+  medium = 'medium',
+  large = 'large'
 }

--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -10,15 +10,18 @@
 .icon {
     display: inline-block;
     margin-right: 5px;
+
     &.font {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
         font-family: icomoon;
         font-style: normal;
     }
-    &.svg {
-        vertical-align: middle;
-        fill: #4D4D4F;
+
+    &.svg {  
+        position:relative;              
+        top: 1px;
+        fill: $secondary-color;
     }
 }
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
-import { IIconProps } from './Icon.Props';
+import { IIconProps, IconSize } from './Icon.Props';
 import { getNativeAttributes, htmlElementAttributes } from '../../utilities/attributes';
 
 import './Icon.scss';
@@ -9,19 +9,41 @@ export const Icon: (props: IIconProps) => JSX.Element = (props: IIconProps) => {
     const customIcon = props.iconName === '';
     const svgIcon = props.iconName && props.iconName.startsWith('svg');
     let iconPrefix = 'icon '.concat(svgIcon ? 'svg' : 'font');
-    let iconClassName = classNames(
+    let iconClassName = classNames(        
         [iconPrefix], {
             [props.iconName]: !customIcon
         }, [props.className]);
 
+    let iconHeight: any;
+    let iconWidth: any;
+    
+    switch (props.iconSize) {
+        case IconSize.smallest:
+            iconHeight = '16px';
+            iconWidth = '16px';
+            break;
+        case IconSize.small:
+            iconHeight = '24px';
+            iconWidth = '24px';
+            break;
+        case IconSize.medium:
+            iconHeight = '32px';
+            iconWidth = '32px';
+            break;
+        case IconSize.large:
+            iconHeight = '64px';
+            iconWidth = '64px';
+            break;
+        default:
+        iconHeight = props.height || '16px';
+        iconWidth = props.width || '16px';
+    }
+
     if (svgIcon) {
-        return <svg className={iconClassName} width={props.width} height={props.height}>
+        return <svg className={iconClassName} width={iconWidth} height={iconHeight}>
             <use xlinkHref={'#symbol-defs_' + props.iconName} />
         </svg>;
     } else {
         return <i { ...getNativeAttributes(props, htmlElementAttributes) } className={iconClassName} />;
     }
-
-
-
 };

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -9,7 +9,7 @@ export const Icon: (props: IIconProps) => JSX.Element = (props: IIconProps) => {
     const customIcon = props.iconName === '';
     const svgIcon = props.iconName && props.iconName.startsWith('svg');
     let iconPrefix = 'icon '.concat(svgIcon ? 'svg' : 'font');
-    let iconClassName = classNames(        
+    let iconClassName = classNames(
         [iconPrefix], {
             [props.iconName]: !customIcon
         }, [props.className]);


### PR DESCRIPTION
The were some problems while using the new svg icon functionalty in the button component. 
The Icon component now has the posibility to define it's size either by using the width and height prop, or by using the iconSize property. The default icon size(for svg) will be 16x16. The font icon behavior is still the same for backward compatibility and the default size is 14x14.

The button component did not work correctly since the colors did not apply to the new icons and the icons were painted using the default color.
 So a bit of css changes were required.
One may wonder, what if we want to use an multicolor icon in a button, will the white fill be problematic? most likely.
For now multicolor icons in the button component are not supported.