### PR TITLE
fixed a bug where the expand node button stayed visible

### DIFF
--- a/src/utilities/rebuildTree.ts
+++ b/src/utilities/rebuildTree.ts
@@ -56,6 +56,7 @@ export function expandOrCollapseAsyncTreeItem(getRoots: () => TreeItem[], treeIt
                 currentItem = {
                     ...currentItem,
                     children: items,
+                    expanded: currentItem.expanded && items.length > 0,
                     hasChildren: items.length > 0,
                     asyncChildrenLoadInProgress: false
                 };


### PR DESCRIPTION
The expand button stayed visible after the async load operation if the node hade no children. 