### PR TITLE
tooltip display content with new line

### DIFF
--- a/examples/src/Tooltip.tsx
+++ b/examples/src/Tooltip.tsx
@@ -23,6 +23,12 @@ export class Index extends React.Component<any, any> {
                         <Button>Hover Over Me</Button>
                     </Tooltip>
                 </div>
+
+                <div style={{ marginLeft: '50px' }}>
+                    <Tooltip content={'This tooltip\r\ndisplay new line!'} directionalHint={DirectionalHint.rightCenter}>
+                        <Button>Hover Over Me</Button>
+                    </Tooltip>
+                </div>
             </div>
         );
     }

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -27,6 +27,7 @@
         .callout-main {
             .tooltip-content span {
                 color: $secondary-color;
+                white-space: pre-line;
             }
         }
     }
@@ -48,6 +49,7 @@
 
             .tooltip-content span {
                 color: $white-color;
+                white-space: pre-line;
             }
         }
     }
@@ -79,6 +81,7 @@
             .tooltip-content span {
                 color: $white-color;
                 font-size: 12px;
+                white-space: pre-line;
             }
         }
     }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -46,7 +46,7 @@ export class Tooltip extends CommonComponent<ITooltipProps, any> {
         );
 
         const tooltipContainerClass = classNames('tooltip-container', [this.props.containerClass]);
-
+        
         return (
             <div
                 ref={this._resolveRef('_tooltipHost')}


### PR DESCRIPTION
In Tooltip.scss I added white-space: pre-line; and now if content has \r\n it'll display as new line