### PR TITLE
Feat/TooltipTitle

### DIFF
--- a/examples/src/Tooltip.tsx
+++ b/examples/src/Tooltip.tsx
@@ -14,21 +14,31 @@ export class Index extends React.Component<any, any> {
     public render() {
         return (
             <div style={{ display: 'inline-flex' }}>
-                <Tooltip content={'This is tooltip! This is tooltip! This is tooltip!'} >
+                <Tooltip content={'This is tooltip! This is tooltip! This is tooltip!\r\nOne more tooltip row! Something to explain'} title={'Tooltip title'} >
                     <Button>Hover Over Me</Button>
                 </Tooltip>
-
                 <div style={{ marginLeft: '50px' }}>
                     <Tooltip content={'This is tooltip'} className={'tooltip-white'} directionalHint={DirectionalHint.rightCenter}>
                         <Button>Hover Over Me</Button>
                     </Tooltip>
                 </div>
-
                 <div style={{ marginLeft: '50px' }}>
-                    <Tooltip content={'This tooltip\r\ndisplay new line!'} directionalHint={DirectionalHint.rightCenter}>
+                    <Tooltip content={'This tooltip\r\ndisplay new line!'} directionalHint={DirectionalHint.rightCenter} >
                         <Button>Hover Over Me</Button>
                     </Tooltip>
                 </div>
+
+                <div style={{ marginLeft: '50px' }}>
+                    <Tooltip content={'This is error tooltip'} className={'tooltip-error'} directionalHint={DirectionalHint.rightCenter} >
+                        <Button>Hover Over Me</Button>
+                    </Tooltip>
+                </div>
+                <div style={{ marginLeft: '50px' }}>
+                    <Tooltip content={'This is error tooltip, because an error occured'} title={'Error tooltip title'}className={'tooltip-error'} directionalHint={DirectionalHint.rightCenter} >
+                        <Button>Hover Over Me</Button>
+                    </Tooltip>
+                </div>
+
             </div>
         );
     }

--- a/src/components/Tooltip/Tooltip.props.ts
+++ b/src/components/Tooltip/Tooltip.props.ts
@@ -1,6 +1,7 @@
 import { DirectionalHint } from '../../utilities/DirectionalHint';
 
 export interface ITooltipProps {
+    title?: string;
     content: string;
     className?: string;
     targetElement?: HTMLElement;

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -29,6 +29,10 @@
                 color: $secondary-color;
                 white-space: pre-line;
             }
+            .tooltip-content .tooltip-title{
+                font-weight: bold;
+                font-size: 14px;
+            }
         }
     }
 
@@ -50,6 +54,12 @@
             .tooltip-content span {
                 color: $white-color;
                 white-space: pre-line;
+                font-size: 12px;
+            }
+            .tooltip-content .tooltip-title{
+                font-weight: bold;
+                font-size: 14px;
+                
             }
         }
     }
@@ -59,7 +69,7 @@
     }
 
     .callout-main {
-        padding: 12px 20px;
+        padding: 12px 15px;
     }
 
     &.tooltip-error {
@@ -82,6 +92,11 @@
                 color: $white-color;
                 font-size: 12px;
                 white-space: pre-line;
+            }
+
+            .tooltip-content .tooltip-title{
+                font-weight: bold;
+                font-size: 14px;
             }
         }
     }

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -58,8 +58,7 @@
             }
             .tooltip-content .tooltip-title{
                 font-weight: bold;
-                font-size: 14px;
-                
+                font-size: 14px;               
             }
         }
     }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -35,7 +35,7 @@ export class Tooltip extends CommonComponent<ITooltipProps, any> {
     }
 
     public render() {
-        let { className, targetElement, directionalHint, content, children } = this.props;
+        let { className, targetElement, directionalHint, content, children, title } = this.props;
 
         const tooltipClassName = classNames(
             'tooltip-callout',
@@ -46,7 +46,7 @@ export class Tooltip extends CommonComponent<ITooltipProps, any> {
         );
 
         const tooltipContainerClass = classNames('tooltip-container', [this.props.containerClass]);
-        
+
         return (
             <div
                 ref={this._resolveRef('_tooltipHost')}
@@ -66,6 +66,11 @@ export class Tooltip extends CommonComponent<ITooltipProps, any> {
                         isBeakVisible={true}
                         gapSpace={0}>
                         <div className="tooltip-content" role="tooltip">
+                            {title &&
+                                <div>
+                                    <span className="tooltip-title">{title}</span>
+                                </div>
+                            }
                             <span>{content}</span>
                         </div>
                     </Callout>
@@ -111,7 +116,7 @@ export class Tooltip extends CommonComponent<ITooltipProps, any> {
         this.setState({
             isTooltipVisible: showTooltipProp && isTooltipVisible
         }, () => this.props.onTooltipToggle(this.state.isTooltipVisible));
-        
+
         this.timer = null;
     }
 }


### PR DESCRIPTION
ToolTip can show titles now. The title is show as bolded text on top of ToolTip content 
The title is optional. Backward compatibility is ensured.

