### PR TITLE
Feat/grid/improvements

### DIFF
--- a/examples/MockData/gridData.ts
+++ b/examples/MockData/gridData.ts
@@ -6,7 +6,7 @@ import { TreeNode, TreeDataSource } from '../../src/models/TreeData';
 const RANDOM_WORDS = ['abstrusity', 'advertisable', 'bellwood', 'benzole', 'disputative', 'djilas', 'ebracteate', 'zonary'];
 const RANDOM_Names = ['Ivan', 'Mario', 'Silvio', 'Hrvoje', 'Vinko', 'Marijana', 'Andrea'];
 const RANDOM_Color = ['Black', 'Green', 'White', 'Blue', 'Orange', 'Red', 'Yellow', 'Gray'];
-const RANDOM_Animal = ['Dog adfasdfa', 'Cat afdsfdas fds fdas ffdfa', 'Mouse af dasf  dasfdsfds fds fds  f'];
+const RANDOM_Animal = ['Dog', 'Cat', 'Mouse'];
 const RANDOM_City = ['Zagreb', 'Vienna', 'London', 'Amsterdam', 'Barcelona'];
 const RANDOM_CarBrand = ['Audi', 'BMW', 'Mercedes', 'Opel', 'VW', 'Lada', 'Ford', 'Mazda'];
 const RANDOM_Mix = ['1', 2, '3', 4, 'A', 'B', 'C', '10'];
@@ -91,7 +91,7 @@ const generateTreeData = (size: number): TreeNode => {
         }
         result.push(treeEntry);
     }
-      alert(totalItems);
+    //  alert(totalItems);
     return {
         children: result
     };

--- a/examples/MockData/gridData.ts
+++ b/examples/MockData/gridData.ts
@@ -6,7 +6,7 @@ import { TreeNode, TreeDataSource } from '../../src/models/TreeData';
 const RANDOM_WORDS = ['abstrusity', 'advertisable', 'bellwood', 'benzole', 'disputative', 'djilas', 'ebracteate', 'zonary'];
 const RANDOM_Names = ['Ivan', 'Mario', 'Silvio', 'Hrvoje', 'Vinko', 'Marijana', 'Andrea'];
 const RANDOM_Color = ['Black', 'Green', 'White', 'Blue', 'Orange', 'Red', 'Yellow', 'Gray'];
-const RANDOM_Animal = ['Dog', 'Cat', 'Mouse'];
+const RANDOM_Animal = ['Dog adfasdfa', 'Cat afdsfdas fds fdas ffdfa', 'Mouse af dasf  dasfdsfds fds fds  f'];
 const RANDOM_City = ['Zagreb', 'Vienna', 'London', 'Amsterdam', 'Barcelona'];
 const RANDOM_CarBrand = ['Audi', 'BMW', 'Mercedes', 'Opel', 'VW', 'Lada', 'Ford', 'Mazda'];
 const RANDOM_Mix = ['1', 2, '3', 4, 'A', 'B', 'C', '10'];
@@ -52,7 +52,7 @@ export const generateTreeNode = () => {
     return {                        
         isExpanded: true,            
         children: [],
-        iconName: 'svg-icon-add',
+        iconName: 'svg-icon-world',
         hasChildren: true,       
         Name: RANDOM_Names[Math.floor(Math.random() * RANDOM_Names.length)],
         Color:  randomLower(RANDOM_Color[Math.floor(Math.random() * RANDOM_Color.length)]),
@@ -91,7 +91,7 @@ const generateTreeData = (size: number): TreeNode => {
         }
         result.push(treeEntry);
     }
-    //  alert(totalItems);
+      alert(totalItems);
     return {
         children: result
     };

--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -18,10 +18,8 @@
         font-style: normal;
     }
 
-    &.svg {  
-        //position:relative;              
-        vertical-align: middle;
-        //top: 1px;
+    &.svg {                     
+        vertical-align: middle;        
         fill: $secondary-color;
     }
 }

--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -19,8 +19,9 @@
     }
 
     &.svg {  
-        position:relative;              
-        top: 1px;
+        //position:relative;              
+        vertical-align: middle;
+        //top: 1px;
         fill: $secondary-color;
     }
 }

--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { ITooltipProps } from '../Tooltip/Tooltip.props';
 
 export enum SortDirection {
     Ascending,
@@ -124,5 +125,6 @@ export interface ActionItem {
     commandName: string;
     iconName?: string;
     parameters?: any;
+    tooltip?: ITooltipProps;
 }
 

--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -34,6 +34,7 @@ export interface IQuickGridProps {
     customRowSorter?: (sortBy, sortDirection) => void;
     customCellRenderer?: (args: ICustomCellRendererArgs) => React.ReactNode;
     hasStaticColumns?: boolean;
+    columnHeadersVisible?: boolean;
 }
 
 export interface ICustomCellRendererArgs {

--- a/src/components/QuickGrid/QuickGrid.scss
+++ b/src/components/QuickGrid/QuickGrid.scss
@@ -145,7 +145,18 @@
         .grid-component-cell {
             user-select: none;            
             display: flex;
-
+            align-items: center;
+            
+            >span {
+                .icon {
+                    margin-right: 0;
+                }
+            }
+            >.grid-component-cell-inner {
+                padding: 0 5px 0 5px;
+                width: 100%;                
+            }
+            
             > div {
                 white-space: nowrap;
                 overflow: hidden;
@@ -171,7 +182,7 @@
             .status-ok {
                 color: $ok-status-server;
             }
-
+        
             .dropdown {
                 padding-left: 5px;
                 
@@ -222,9 +233,11 @@
 
                         >.dropdown-root {
                             height: 16px;
-
+                            position: relative;
+                            top: -4px;
                             >.dropdown {
                                 padding-left: 0;
+                                margin: 0;
                             }
                         }
                     }

--- a/src/components/QuickGrid/QuickGrid.scss
+++ b/src/components/QuickGrid/QuickGrid.scss
@@ -182,7 +182,7 @@
             .status-ok {
                 color: $ok-status-server;
             }
-        
+
             .dropdown {
                 padding-left: 5px;
                 

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -34,7 +34,8 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         groupBy: [],
         rowHeight: 28,
         tooltipsEnabled: true,
-        actionsTooltip: 'Actions'
+        actionsTooltip: 'Actions',
+        columnHeadersVisible: true
     };
 
     private _finalGridRows: Array<any>;
@@ -571,7 +572,8 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                         <ScrollSync>
                             {({ onScroll, scrollLeft }) => (
                                 <div style={{ width, height }} >
-                                    <GridHeader
+                                    {
+                                     this.props.columnHeadersVisible && <GridHeader
                                         ref={this._setHeaderGridReference}
                                         allColumns={this.props.columns}
                                         headerColumns={this.state.columnsToDisplay}
@@ -592,6 +594,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                                         onExpandAll={this.expandAll}
                                         tooltipsEnabled={this.props.tooltipsEnabled}
                                     />
+                                    }
 
                                     <Grid
                                         ref={this._setGridReference}

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -255,8 +255,11 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         const onClick = (e) => {
             // https://github.com/facebook/react/issues/1691 funky bussinese because of multiple mount points in the hover actions            
             // so stopPropagation and preventDefault do not work there, manually checking if row actions were clicked
-            if (e.currentTarget !== e.target && !e.currentTarget.children[0].contains(e.target)) {
-                return;
+            if (e.currentTarget !== e.target) {
+                const rowActionsContainer = e.currentTarget.getElementsByClassName('hoverable-items-container__btn')[0];
+                if (rowActionsContainer && rowActionsContainer.contains(e.target)) {
+                    return;
+                }                
             }
 
             this.setSelectedRowIndex(rowIndex, rowData);
@@ -436,7 +439,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                 return column.cellFormatter(cellData, rowData);
             } else {
                 return (
-                    <div style={{ padding: '3px 5px 0 5px', width: '100%' }} >
+                    <div className="grid-component-cell-inner" >
                         {cellData}
                     </div>
                 );

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -521,6 +521,9 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
     }
 
     groupByToolboxHeight = () => {
+        if (!this.props.columnHeadersVisible) {
+            return 2;
+        }
         return 30 + (this.props.displayGroupContainer ? 62 : 0); // header height + Drag&Drop height+padding
     }
 

--- a/src/components/QuickGrid/QuickGridRowContextActionsHandler.tsx
+++ b/src/components/QuickGrid/QuickGridRowContextActionsHandler.tsx
@@ -127,7 +127,7 @@ function renderActions(rowIndex: number, actions: Array<ActionItem>, onActionCli
 
     const mapAction = (x: ActionItem) => {
         const mappedAction = <Icon key={x.commandName} iconName={x.iconName} title={x.name} className="hoverable-items__btn" onClick={() => onActionClicked(rowIndex, x)} />;
-        return  x.tooltip !== undefined ? <Tooltip {...x.tooltip}> {mappedAction} </Tooltip> : mappedAction;
+        return  x.tooltip !== undefined ? <Tooltip key={x.commandName} {...x.tooltip}> {mappedAction} </Tooltip> : mappedAction;
     };
 
     let renderDropDown = actions.length >= 4;

--- a/src/components/QuickGrid/QuickGridRowContextActionsHandler.tsx
+++ b/src/components/QuickGrid/QuickGridRowContextActionsHandler.tsx
@@ -4,6 +4,7 @@ import { Icon } from '../Icon/Icon';
 import { ActionItem } from './QuickGrid.Props';
 import { Dropdown } from '../Dropdown/Dropdown';
 import { DropdownType } from '../Dropdown/Dropdown.Props';
+import { Tooltip } from '../Tooltip/Tooltip';
 
 
 export interface IQuickGridRowAContextActionsHandlerProps {
@@ -42,12 +43,12 @@ export class QuickGridRowContextActionsHandler extends React.PureComponent<IQuic
             return;
         }
 
-        if (this._hoveredRowIndex && this._hoveredRowIndex !== -1) {
+        if (this._hoveredRowIndex !== undefined && this._hoveredRowIndex !== -1) {
             this._removeHoveredStyle(this._hoveredRowIndex);
             this.clearHoveredElement(false);
         }
 
-        if (rowIndex && rowIndex !== -1) {
+        if (rowIndex !== undefined && rowIndex !== -1) {
 
             let rowClass = 'grid-row-' + rowIndex;
             let rowElements = this._gridElement.getElementsByClassName(rowClass);
@@ -124,7 +125,11 @@ function renderActions(rowIndex: number, actions: Array<ActionItem>, onActionCli
         return null;
     }
 
-    const mapAction = (x: ActionItem) => <Icon key={x.commandName} iconName={x.iconName} title={x.name} className="hoverable-items__btn" onClick={() => onActionClicked(rowIndex, x)} />;
+    const mapAction = (x: ActionItem) => {
+        const mappedAction = <Icon key={x.commandName} iconName={x.iconName} title={x.name} className="hoverable-items__btn" onClick={() => onActionClicked(rowIndex, x)} />;
+        return  x.tooltip !== undefined ? <Tooltip {...x.tooltip}> {mappedAction} </Tooltip> : mappedAction;
+    };
+
     let renderDropDown = actions.length >= 4;
     let elements = [];
     if (renderDropDown) {
@@ -152,7 +157,7 @@ function renderActions(rowIndex: number, actions: Array<ActionItem>, onActionCli
         elements = actions.map(mapAction);
     }
 
-    return <span key="hoverActionsSpan" className="hoverable-items-inner-container">
+    return <span key="hoverActionsSpan" className="hoverable-items-inner-container" title="">
         {
             elements
         }

--- a/src/components/TreeGrid/TreeGrid.Props.ts
+++ b/src/components/TreeGrid/TreeGrid.Props.ts
@@ -12,6 +12,7 @@ export interface ITreeGridProps {
     sortColumn?: string;
     sortDirection?: SortDirection;
     columnSummaries?: any;
+    columnHeadersVisible?: boolean;
 }
 
 export interface ITreeGridState {    

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -31,8 +31,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         let emptyArray = new Array();
         emptyArray.push({
             isSortable: false,
-            width: 18,
-            minWidth: 30,
+            width: 16,
             fixedWidth: true
         });
         emptyArray.push({
@@ -92,8 +91,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         if (columnIndex === 0) {
             return this._renderExpandCollapseButton(key, rowIndex, rowData, style, onMouseEnter, args.isSelectedRow);
         }
-
-        // return defaultRender(style);
+         
         return this._renderBodyCell(columnIndex, key, rowIndex, rowData, style, onMouseEnter, onMouseClick, rowActionsRender, args.isSelectedRow);
     }
 
@@ -109,7 +107,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
 
     private _renderExpandCollapseButton(key, rowIndex: number, rowData: IFinalTreeNode, style, onMouseEnter, isSelectedRow: boolean) {
         let actionsTooltip = rowData.isExpanded ? 'Collapse' : 'Expand';
-        let iconName = rowData.isExpanded ? 'icon-arrow_down' : 'icon-arrow_right';
+        let iconName = rowData.isExpanded ? 'svg-icon-arrow_down' : 'svg-icon-arrow_right';
         let icon = null;
 
         if (rowData.children.length <= 0 && !rowData.hasChildren) {
@@ -122,6 +120,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         const title = actionsTooltip;
         const className = classNames(
             'grid-component-cell',
+            'expand-collapse-cell',
             rowClass,
             { 'is-selected': isSelectedRow }
         );
@@ -157,6 +156,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
             { 'is-selected': isSelectedRow });
 
         let columnElement: any;
+        onCellClick =  rowData.isAsyncLoadingDummyNode ? undefined : onCellClick;
         if (rowData.isAsyncLoadingDummyNode && columnIndex === 2) {
             columnElement = <div className="loading-container">
                 <Spinner className="async-loading-spinner"
@@ -170,8 +170,8 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
             columnElement = column.cellFormatter(cellData, rowData);
         } else {
             columnElement = [
-                <div key="cellData" style={{ padding: '3px 5px 0 5px', width: '100%' }} >
-                    {columnIndex === 2 && rowData.iconName ? <Icon iconName={rowData.iconName} /> : null}
+                columnIndex === 2 && rowData.iconName ? <span style={{display: 'flex'}} title={rowData.iconTooltipContent}><Icon iconName={rowData.iconName} /></span> : null,
+                <div key="cellData" className="grid-component-cell-inner" >                    
                     {cellData}
                 </div>
             ];
@@ -240,7 +240,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
                 customCellRenderer={this.treeCellRenderer}
                 hasCustomRowSelector={true}
                 hasStaticColumns={true}
-                customRowSorter={this._getSortInfo}
+                customRowSorter={this._getSortInfo}                
                 columnSummaries={this.props.columnSummaries}
                 columnHeadersVisible={this.props.columnHeadersVisible}
             />

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -242,6 +242,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
                 hasStaticColumns={true}
                 customRowSorter={this._getSortInfo}
                 columnSummaries={this.props.columnSummaries}
+                columnHeadersVisible={this.props.columnHeadersVisible}
             />
         );
     }

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -32,6 +32,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         emptyArray.push({
             isSortable: false,
             width: 16,
+            minWidth: 30,
             fixedWidth: true
         });
         emptyArray.push({
@@ -171,7 +172,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         } else {
             columnElement = [
                 columnIndex === 2 && rowData.iconName ? <span style={{display: 'flex'}} title={rowData.iconTooltipContent}><Icon iconName={rowData.iconName} /></span> : null,
-                <div key="cellData" className="grid-component-cell-inner" >                    
+                <div key="cellData" className="grid-component-cell-inner" >
                     {cellData}
                 </div>
             ];
@@ -240,7 +241,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
                 customCellRenderer={this.treeCellRenderer}
                 hasCustomRowSelector={true}
                 hasStaticColumns={true}
-                customRowSorter={this._getSortInfo}                
+                customRowSorter={this._getSortInfo}
                 columnSummaries={this.props.columnSummaries}
                 columnHeadersVisible={this.props.columnHeadersVisible}
             />

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -171,7 +171,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
             columnElement = column.cellFormatter(cellData, rowData);
         } else {
             columnElement = [
-                columnIndex === 2 && rowData.iconName ? <span style={{display: 'flex'}} title={rowData.iconTooltipContent}><Icon iconName={rowData.iconName} /></span> : null,
+                columnIndex === 2 && rowData.iconName ? <span key="cellIcon" style={{display: 'flex'}} title={rowData.iconTooltipContent}><Icon iconName={rowData.iconName} /></span> : null,
                 <div key="cellData" className="grid-component-cell-inner" >
                     {cellData}
                 </div>

--- a/src/models/TreeData.ts
+++ b/src/models/TreeData.ts
@@ -3,6 +3,7 @@ export interface TreeNode { // extend this interface on a data structure to be u
     children: Array<TreeNode>;
     hasChildren?: boolean;
     iconName?: string;
+    iconTooltipContent?: string;
 }
 
 export interface IFinalTreeNode extends TreeNode {


### PR DESCRIPTION
- solved some svg icon issues in the treegrid 
- solved a problem with row selection and hover icons clashing
- added a prop to hide the column headers
- solved a bug where you could not hover over the first row
- the dummy loading node is no longer selectable
- added tooltips to node icons and node actions
