### PR TITLE
Feat/grid actions dropdown tooltips

### DIFF
--- a/examples/src/QuickGrid.tsx
+++ b/examples/src/QuickGrid.tsx
@@ -26,10 +26,34 @@ const columnSummaries = {
 export class Index extends React.Component<any, any> {
     gridActions: QuickGridActions = {
         actionItems: [
-            { name: 'Action 1', iconName: 'icon-add', commandName: 'command1' },
-            { name: 'Action 2', iconName: 'icon-user', commandName: 'command2' },
-            { name: 'Action 3', commandName: 'command3' },
-            { name: 'Action 4', commandName: 'command4', parameters: { key: 'someParam' } }
+            {
+                name: 'Action 1', iconName: 'icon-add', commandName: 'command1',
+                tooltip: {
+                    content: 'Action 1 tooltip content',
+                    title: 'Action 1'
+                }
+            },
+            {
+                name: 'Action 2', iconName: 'icon-user', commandName: 'command2',
+                tooltip: {
+                    content: 'Action 2 tooltip content',
+                    title: 'Action 2'
+                }
+            },
+            {
+                name: 'Action 3', iconName: 'icon-user', commandName: 'command3',
+                tooltip: {
+                    content: 'Action 3 tooltip content',
+                    title: 'Action 3'
+                }
+            },
+            {
+                name: 'Action 4', iconName: 'icon-user', commandName: 'command4', parameters: { key: 'someParam' },
+                tooltip: {
+                    content: 'Action 4 tooltip content',
+                    title: 'Action 4'
+                }
+            }
         ],
         actionsBehaviour: QuickGridActionsBehaviourEnum.ShowOnRowHover,
         actionIconName: 'icon-ghost',
@@ -39,7 +63,7 @@ export class Index extends React.Component<any, any> {
             alert(commandName + ' clicked.');
         }
     };
-    
+
     state = {
         data: getGridData(numOfRows),
         columns: gridColumns2,
@@ -65,9 +89,9 @@ export class Index extends React.Component<any, any> {
                             ]}
                     />
                 </div>
-                <Checkbox label="Show actions as row context actions" 
-                checked={this.state.gridActions.actionsBehaviour === QuickGridActionsBehaviourEnum.ShowOnRowHover} 
-                onChange={this.onRowHoverActionsChecked } /> <br />
+                <Checkbox label="Show actions as row context actions"
+                    checked={this.state.gridActions.actionsBehaviour === QuickGridActionsBehaviourEnum.ShowOnRowHover}
+                    onChange={this.onRowHoverActionsChecked} /> <br />
                 <Button onClick={this.refreshData}>Refresh data</Button>
 
                 <Resizable width={1000} height={700} >
@@ -89,10 +113,10 @@ export class Index extends React.Component<any, any> {
         );
     }
 
-    onRowHoverActionsChecked = (ev, value) => {        
+    onRowHoverActionsChecked = (ev, value) => {
         this.setState(prev => {
-            const newBehaviour =  prev.gridActions.actionsBehaviour === QuickGridActionsBehaviourEnum.ShowAsFirstColumn  ? QuickGridActionsBehaviourEnum.ShowOnRowHover : QuickGridActionsBehaviourEnum.ShowAsFirstColumn;
-            return { gridActions: {...prev.gridActions, actionsBehaviour: newBehaviour }};
+            const newBehaviour = prev.gridActions.actionsBehaviour === QuickGridActionsBehaviourEnum.ShowAsFirstColumn ? QuickGridActionsBehaviourEnum.ShowOnRowHover : QuickGridActionsBehaviourEnum.ShowAsFirstColumn;
+            return { gridActions: { ...prev.gridActions, actionsBehaviour: newBehaviour } };
         });
     }
 

--- a/src/components/Dropdown/Dropdown.Props.ts
+++ b/src/components/Dropdown/Dropdown.Props.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { DirectionalHint } from '../../index';
 
 export interface IRenderFunction<P> {
     (props?: P, defaultRender?: (props?: P) => JSX.Element): JSX.Element;
@@ -36,6 +37,7 @@ export interface IDropdownOption {
     selected?: boolean;
     href?: string;
     icon?: string;
+    tooltipInfo?: { title: string, content: string, directionalHint?: DirectionalHint; };
 }
 
 export enum DropdownType {

--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -255,6 +255,10 @@
                     cursor: pointer;
                     display: block;
 
+                    >.tooltip-container {
+                        display: block;
+                    }
+
                     &.is-selected {
                         background-color: $white-color;
                         color: $primary-color;
@@ -263,7 +267,15 @@
                     &:hover {
                         background-color: $primary-background-hover-color;
                     }
-                }
+
+                    &.has-tooltip {
+                        padding: 0;
+
+                        >.tooltip-container {
+                            padding: 0 10px;
+                        }
+                    }
+                }               
             }
         }
     }

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -3,6 +3,7 @@ import { IDropdownProps, IDropdownOption, DropdownType } from './Dropdown.Props'
 import { DirectionalHint } from '../../utilities/DirectionalHint';
 import { Callout } from '../Callout/Callout';
 import { Icon } from '../Icon/Icon';
+import { Tooltip } from '../ToolTip/Tooltip';
 import { KeyCodes } from '../../utilities/KeyCodes';
 import * as classNames from 'classnames';
 import { findIndex } from '../../utilities/array';
@@ -151,7 +152,7 @@ export class Dropdown extends React.PureComponent<IDropdownProps, IDropdownState
         if (this.props.dropdownType !== DropdownType.actionDropdown && this.props.options.length > 0) {
             let longest = this.props.options.reduce((a, b) => { return a.text.length > b.text.length ? a : b; });
             const arrowIconWidth = this.props.showArrowIcon ? 50 : 25;
-            const accualWitdh = longest.text.length * 8  + arrowIconWidth;
+            const accualWitdh = longest.text.length * 8 + arrowIconWidth;
             return Math.max(accualWitdh, 60) + 'px';
         }
         return;
@@ -190,15 +191,26 @@ export class Dropdown extends React.PureComponent<IDropdownProps, IDropdownState
                 {options && options.map((option, index) => (
                     <li
                         id={id + '-list' + option.key}
-                        title={option.text}
+                        title={option.tooltipInfo ? undefined : option.text}
                         key={option.key}
                         data-index={index}
-                        className={'dropdown-item'}
+                        className={classNames('dropdown-item', { 'has-tooltip': option.tooltipInfo !== undefined })}
                         onClick={() => this.onActionItemClick(option, index)}
                         role="option"
                     >
-                        {option.icon ? <Icon iconName={option.icon}></Icon> : null}
-                        {option.text}
+                        {
+                            option.tooltipInfo && <Tooltip {...option.tooltipInfo} delayMs={1000}>
+                                {option.icon ? <Icon iconName={option.icon}></Icon> : null}
+                                {option.text}
+                            </Tooltip>
+                        }
+                        {
+                            !option.tooltipInfo && option.icon ? <Icon iconName={option.icon}></Icon> : null
+                        }
+                        {
+                            !option.tooltipInfo && option.text
+                        }
+
                     </li>
                 ))}
             </ul>
@@ -225,17 +237,26 @@ export class Dropdown extends React.PureComponent<IDropdownProps, IDropdownState
                 {options && options.map((option, index) => (
                     <li id={id + '-list' + index.toString()}
                         ref={Dropdown.Option + index.toString()}
-                        title={option.text}
+                        title={option.tooltipInfo ? undefined : option.text}
                         key={option.key}
                         data-index={index}
                         data-is-focusable={true}
-                        className={classNames('dropdown-item', { 'is-selected': selectedIndex === index })}
+                        className={classNames('dropdown-item', { 'is-selected': selectedIndex === index, 'has-tooltip': option.tooltipInfo !== undefined })}
                         onClick={() => this._onItemClick(index)}
                         onFocus={() => this.setSelectedIndex(index)}
                         role="option">
-                        {option.icon ? <Icon iconName={option.icon}></Icon>
-                            : null}
-                        {option.text}
+                        {
+                            option.tooltipInfo && <Tooltip {...option.tooltipInfo} delayMs={1000}>
+                                {option.icon ? <Icon iconName={option.icon}></Icon> : null}
+                                {option.text}
+                            </Tooltip>
+                        }
+                        {
+                            !option.tooltipInfo && option.icon ? <Icon iconName={option.icon}></Icon> : null
+                        }
+                        {
+                            !option.tooltipInfo && option.text
+                        }
                     </li>
                 ))}
             </ul>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -3,7 +3,7 @@ import { IDropdownProps, IDropdownOption, DropdownType } from './Dropdown.Props'
 import { DirectionalHint } from '../../utilities/DirectionalHint';
 import { Callout } from '../Callout/Callout';
 import { Icon } from '../Icon/Icon';
-import { Tooltip } from '../ToolTip/Tooltip';
+import { Tooltip } from '../Tooltip/Tooltip';
 import { KeyCodes } from '../../utilities/KeyCodes';
 import * as classNames from 'classnames';
 import { findIndex } from '../../utilities/array';

--- a/src/components/QuickGrid/QuickGridRowContextActionsHandler.tsx
+++ b/src/components/QuickGrid/QuickGridRowContextActionsHandler.tsx
@@ -5,6 +5,7 @@ import { ActionItem } from './QuickGrid.Props';
 import { Dropdown } from '../Dropdown/Dropdown';
 import { DropdownType } from '../Dropdown/Dropdown.Props';
 import { Tooltip } from '../Tooltip/Tooltip';
+import { DirectionalHint } from '../../index';
 
 
 export interface IQuickGridRowAContextActionsHandlerProps {
@@ -117,7 +118,7 @@ export class QuickGridRowContextActionsHandler extends React.PureComponent<IQuic
 
     componentWillUnmount() {
         this.clearHoveredElement();
-    }    
+    }
 }
 
 function renderActions(rowIndex: number, actions: Array<ActionItem>, onActionClicked: (rowIndex: number, action: ActionItem) => void, onMenuToggle: (opened: boolean) => void) {
@@ -126,8 +127,8 @@ function renderActions(rowIndex: number, actions: Array<ActionItem>, onActionCli
     }
 
     const mapAction = (x: ActionItem) => {
-        const mappedAction = <Icon key={x.commandName} iconName={x.iconName} title={x.name} className="hoverable-items__btn" onClick={() => onActionClicked(rowIndex, x)} />;
-        return  x.tooltip !== undefined ? <Tooltip key={x.commandName} {...x.tooltip}> {mappedAction} </Tooltip> : mappedAction;
+        const mappedAction = <Icon key={x.commandName} iconName={x.iconName} title={x.tooltip ? undefined : x.name} className="hoverable-items__btn" onClick={() => onActionClicked(rowIndex, x)} />;
+        return x.tooltip !== undefined ? <Tooltip key={x.commandName} {...x.tooltip} delayMs={1000} >  {mappedAction} </Tooltip> : mappedAction;
     };
 
     let renderDropDown = actions.length >= 4;
@@ -137,7 +138,11 @@ function renderActions(rowIndex: number, actions: Array<ActionItem>, onActionCli
         elements.push(mapAction(actions[1]));
         let actionOptions = [];
         for (let i = 2; i < actions.length; i++) {
-            actionOptions.push({ key: actions[i].commandName, icon: actions[i].iconName, text: actions[i].name });
+            let tooltipInfo = actions[i].tooltip;
+            if (tooltipInfo && !tooltipInfo.directionalHint) {
+                tooltipInfo = { ...tooltipInfo, directionalHint: DirectionalHint.leftCenter };
+            }
+            actionOptions.push({ key: actions[i].commandName, icon: actions[i].iconName, text: actions[i].name, tooltipInfo });
         }
         elements.push(
             <Dropdown

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -34,6 +34,12 @@ export class Tooltip extends CommonComponent<ITooltipProps, any> {
         }
     }
 
+    public componentWillUnmount() {
+        if (this.timer && this.timer !== null) {
+            clearTimeout(this.timer);
+        }
+    }
+
     public render() {
         let { className, targetElement, directionalHint, content, children, title } = this.props;
 
@@ -86,6 +92,9 @@ export class Tooltip extends CommonComponent<ITooltipProps, any> {
     // Show Tooltip
     @autobind
     private _onTooltipMouseEnter(ev: any) {
+        if (this.timer !== null) {
+            return;
+        }
         this.timer = setTimeout(() => this._toggleTooltip(true), this.props.delayMs);
     }
 


### PR DESCRIPTION
Added tooltip functionality to the dropdown component. 

Fixed the bug where the tooltips went wild and would not close. It had to do with the entered event firing multiple times, this created multiple timers some of which were not cleared when the leave event was fired