### PR TITLE
added pivot item text size functionality

### DIFF
--- a/examples/src/Pivot.tsx
+++ b/examples/src/Pivot.tsx
@@ -64,6 +64,18 @@ export class Index extends React.Component<any, any> {
                         <Label>Pivot #3</Label>
                     </PivotItem>
                 </Pivot>
+                <br />
+                <Pivot onLinkClick={(item, ev) => console.log(item)} textSize={22} >
+                    <PivotItem linkText={'My Files'} itemCount={10}>
+                        <Label>Pivot #1</Label>
+                    </PivotItem>
+                    <PivotItem linkText={'Recent'} disabled={true}>
+                        <Label>Pivot #2</Label>
+                    </PivotItem>
+                    <PivotItem linkText={'Shared with me'}>
+                        <Label>Pivot #3</Label>
+                    </PivotItem>
+                </Pivot>
             </div>
         );
     }

--- a/src/components/Pivot/Pivot.Props.ts
+++ b/src/components/Pivot/Pivot.Props.ts
@@ -8,6 +8,7 @@ export interface IPivotProps extends React.Props<Pivot> {
     onLinkClick?: (item?: PivotItem, ev?: React.MouseEvent<any>) => void;
     linkFormat?: PivotLinkFormat;
     className?: string;
+    textSize?: number;
 }
 
 export enum PivotLinkFormat {

--- a/src/components/Pivot/Pivot.tsx
+++ b/src/components/Pivot/Pivot.tsx
@@ -90,6 +90,11 @@ export class Pivot extends React.Component<IPivotProps, IPivotState> {
         const { itemKey, itemCount } = link;
         let { id } = this.state;
         let countText;
+        let { textSize } = this.props;
+        let textStyle;
+        if (textSize) {
+            textStyle = {fontSize: textSize};
+        }
 
         if (itemCount !== undefined && this.props.linkFormat !== PivotLinkFormat.tabs) {
             countText = <span className={'pivot-count'}>({itemCount})</span>;
@@ -111,7 +116,7 @@ export class Pivot extends React.Component<IPivotProps, IPivotState> {
                     <Icon iconName={link.linkIcon} className={'pivot-icon'} title={link.linkText} />
                 }
                 {!link.linkIcon &&
-                    <span className={'pivot-text'}>{link.linkText}</span>
+                    <span className={'pivot-text'} style={textStyle}>{link.linkText}</span>
                 }
                 {countText}
             </a>

--- a/src/components/Pivot/Pivot.tsx
+++ b/src/components/Pivot/Pivot.tsx
@@ -88,14 +88,13 @@ export class Pivot extends React.Component<IPivotProps, IPivotState> {
 
     private _renderLink(link: IPivotItemProps) {
         const { itemKey, itemCount } = link;
-        let { id } = this.state;
+        const { textSize } = this.props;
+        const { id } = this.state;
         let countText;
-        let { textSize } = this.props;
         let textStyle;
         if (textSize) {
             textStyle = {fontSize: textSize};
         }
-
         if (itemCount !== undefined && this.props.linkFormat !== PivotLinkFormat.tabs) {
             countText = <span className={'pivot-count'}>({itemCount})</span>;
         }


### PR DESCRIPTION
nothing really smart going on here. i did consider adding it as a className prop but then you have to wonder why the container of the text does not also have a className. So we would have the existing className, pivotLinkItemClassName, pivotLinkTextClassName which seemed as overkill.