### PR TITLE
tree data can now be any datasource

### DIFF
--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -143,7 +143,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         let iconName = rowData.isExpanded ? 'svg-icon-arrowCollapse' : 'svg-icon-arrowExpand';
         let icon = null;
 
-        if (rowData.children.length <= 0 && !rowData.hasChildren) {
+        if ((!rowData.children || rowData.children.length <= 0) && !rowData.hasChildren) {
             icon = null;
             actionsTooltip = null;
         } else {
@@ -251,7 +251,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         // we are breaking immutability here and potential redux stores, but we need the performance
         rowData.isExpanded = !rowData.isExpanded;
         if (rowData.isExpanded
-            && rowData.children.length === 0
+            && (!rowData.children || rowData.children.length === 0)
             && rowData.hasChildren
             && this.props.onLazyLoadChildNodes
             && !rowData.isLazyChildrenLoadInProgress) {

--- a/src/components/TreeGrid/TreeGridDataSelectors.ts
+++ b/src/components/TreeGrid/TreeGridDataSelectors.ts
@@ -1,5 +1,5 @@
 import { ITreeGridState, ITreeGridProps } from './TreeGrid.Props';
-import { SortDirection, GridColumn } from '../QuickGrid/QuickGrid.Props'; 
+import { SortDirection, GridColumn } from '../QuickGrid/QuickGrid.Props';
 import { TreeNode, TreeDataSource, IFinalTreeNode } from '../../models/TreeData';
 const createSelector = require('reselect').createSelector;
 
@@ -32,7 +32,7 @@ const transformData = (tree: TreeDataSource,
     sortData(root, sortColumn, sortDirection, sortRequestId);
     let flattenedData: Array<IFinalTreeNode> = [];
     let maxExpandedLevel = flatten(root.children, flattenedData);
-    return { data: flattenedData, maxExpandedLevel};
+    return { data: flattenedData, maxExpandedLevel };
 };
 
 const sortData = (treeNode: IFinalTreeNode, sortColumn: string, sortDirection: SortDirection, rootSortRequestId: number): void => {
@@ -102,7 +102,7 @@ function filterNodes(root: IFinalTreeNode, arg: ((node: IFinalTreeNode) => boole
             let visible = false;
             for (let column of columns) {
                 let value = node[column];
-                if (typeof value  === 'string' && value.toLowerCase().search(filterText) !== -1) {
+                if (typeof value === 'string' && value.toLowerCase().search(filterText) !== -1) {
                     return true;
                 }
             }
@@ -113,6 +113,9 @@ function filterNodes(root: IFinalTreeNode, arg: ((node: IFinalTreeNode) => boole
 
     let processNode = (node: IFinalTreeNode): boolean => {
 
+        if (!node.children) {
+            return node.isVisible;
+        }
         let anyChildVisible = false;
         for (let child of node.children) {
             anyChildVisible = processNode(child) || anyChildVisible;
@@ -128,19 +131,19 @@ function filterNodes(root: IFinalTreeNode, arg: ((node: IFinalTreeNode) => boole
     processNode(root);
 }
 
-export function flatten(tree, resultArray: Array<IFinalTreeNode>, level: number = 0) : number {
+export function flatten(tree, resultArray: Array<IFinalTreeNode>, level: number = 0): number {
     level++;
     let maxChildLevel = level;
     for (let child of tree) {
-        
+
         if (child.isVisible === false) {
             continue;
         }
         let thisChildDepth = child.nodeLevel;
         resultArray.push(child);
         if (child.children && child.children.length > 0 && child.isExpanded) {
-           thisChildDepth =  flatten(child.children, resultArray, level);
-           
+            thisChildDepth = flatten(child.children, resultArray, level);
+
         } else if (child.hasChildren && child.isExpanded && (!child.children || child.children.length === 0)) {
             resultArray.push(<IFinalTreeNode>{
                 nodeLevel: child.nodeLevel + 1,

--- a/src/models/TreeData.ts
+++ b/src/models/TreeData.ts
@@ -1,6 +1,6 @@
 export interface TreeNode { // extend this interface on a data structure to be used for row data    
     isExpanded?: boolean;
-    children: Array<TreeNode>;
+    children?: Array<TreeNode>;
     hasChildren?: boolean;
     iconName?: string;
     iconTooltipContent?: string;
@@ -47,7 +47,7 @@ export class TreeDataSource {
      * 
      * @param root warning: will be mutated and returned as ITreeDataSource
      */
-    constructor(input: TreeNode | TreeDataSource | Array<TreeNode>) {
+    constructor(input: TreeNode | TreeDataSource | Array<any>) {
         if (this.isDataSource(input)) {
             this.nodesById = input.nodesById;
             this.idCounter = input.idCounter;
@@ -83,11 +83,11 @@ export class TreeDataSource {
         }
     }
 
-    private isDataSource(input: TreeNode | TreeDataSource | Array<TreeNode>): input is TreeDataSource {
+    private isDataSource(input: TreeNode | TreeDataSource | Array<any>): input is TreeDataSource {
         return (<TreeDataSource>input).updateNode !== undefined;
     }
 
-    private isRootNodesArray(input: TreeNode | TreeDataSource | Array<TreeNode>): input is Array<TreeNode> {
+    private isRootNodesArray(input: TreeNode | TreeDataSource| Array<any>): input is Array<any> {
         return (<Array<TreeNode>>input).slice !== undefined;
     }
 

--- a/src/models/TreeData.ts
+++ b/src/models/TreeData.ts
@@ -88,7 +88,7 @@ export class TreeDataSource {
     }
 
     private isRootNodesArray(input: TreeNode | TreeDataSource| Array<any>): input is Array<any> {
-        return (<Array<TreeNode>>input).slice !== undefined;
+        return (<Array<any>>input).slice !== undefined;
     }
 
     public updateNode<T>(nodeId: number, props: Partial<IFinalTreeNode & T>): TreeDataSource;    


### PR DESCRIPTION
We started to use the TreeGrid component also for non-hierarchical data, as such it became weird to extend the treenode interface when you just have a simple list of items.

Now we can just pass any old array of objects and it should work.