### PR TITLE
fix for padding for suggestion list

### DIFF
--- a/src/components/PeoplePicker/PeoplePicker.scss
+++ b/src/components/PeoplePicker/PeoplePicker.scss
@@ -41,7 +41,6 @@
     .people-picker-suggestions {
         display: flex;
         flex-direction: column;
-        justify-content: space-around;
         box-sizing: border-box;
         border: 1px solid $white-background-lines;
         border-radius: 8px;
@@ -58,6 +57,10 @@
 
         .no-result {
             padding: 5px 0px 5px 10px;
+        }
+
+        .suggestion-loading {
+            padding: 10px 0px 10px 10px;
         }
     }
 

--- a/src/components/PeoplePicker/PeoplePicker.tsx
+++ b/src/components/PeoplePicker/PeoplePicker.tsx
@@ -71,7 +71,9 @@ export class PeoplePicker extends React.PureComponent<IPeoplePickerProps, IPeopl
         let allSelected: boolean = true;
         return (
             <div className="people-picker-suggestions">
-                {this.props.loadingSuggestionList && <Spinner type={SpinnerType.small} />}
+                {this.props.loadingSuggestionList && <div className="suggestion-loading">
+                    <Spinner type={SpinnerType.small} />
+                </div>}
                 {!this.props.loadingSuggestionList && this.props.suggestionList.length > 0 && this.props.suggestionList.map((principal, index) => {
                     const alreadySelected = this.state.selectedPrincipalList
                         && this.state.selectedPrincipalList.find(selected => selected.identifier === principal.identifier) !== undefined;


### PR DESCRIPTION
- justify content caused a bug in rendering suggestion list when there was too many suggestion (first one was barely visible). Removing justify-content we needed to recenter the loading spinner