### PR TITLE
Bug/tree grid search

### DIFF
--- a/examples/src/TreeGrid.tsx
+++ b/examples/src/TreeGrid.tsx
@@ -27,7 +27,7 @@ export class Index extends React.Component<any, any> {
         data: getTreeGridData(0),
         columns: gridColumns1,
         selectedData: 1,
-        searchText: undefined
+        searchText: ''
     };
 
     gridActions: QuickGridActions = {

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -139,8 +139,9 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
     }
 
     private _renderExpandCollapseButton(key, rowIndex: number, rowData: IFinalTreeNode, style, onMouseEnter, isSelectedRow: boolean) {
-        let actionsTooltip = rowData.isExpanded ? 'Collapse' : 'Expand';
-        let iconName = rowData.isExpanded ? 'svg-icon-arrowCollapse' : 'svg-icon-arrowExpand';
+        const showNodeAsExpanded = rowData.isExpanded || rowData.descendantSatisfiesFilterCondition;
+        let actionsTooltip = showNodeAsExpanded ? 'Collapse' : 'Expand';
+        let iconName = showNodeAsExpanded ? 'svg-icon-arrowCollapse' : 'svg-icon-arrowExpand';
         let icon = null;
 
         if ((!rowData.children || rowData.children.length <= 0) && !rowData.hasChildren) {

--- a/src/models/TreeData.ts
+++ b/src/models/TreeData.ts
@@ -15,7 +15,8 @@ export interface IFinalTreeNode extends TreeNode {
     isAsyncLoadingDummyNode?: boolean;
     children: Array<IFinalTreeNode>;
     parent: IFinalTreeNode;
-    isVisible?: boolean;
+    satisfiesFilterCondition?: boolean;
+    descendantSatisfiesFilterCondition?: boolean;
 }
 
 interface ILookupTable {


### PR DESCRIPTION
Fixed the search on the TreeGrid. The previous implementation had problems when children was undefined and the search would not work. Also, the new implementation respects the isExpanded property, after the search is over the isExpanded property will return to the before search state. This is important because if we type slow and start the search with 'a' this will expand a lot of tree nodes because they satisfy the search. Of course when we actually type in the whole search query we will get only our desired node, but the side effect was that we expanded all of the other nodes. One side effect of this new behavior is that you cannot collapse nodes while search is active. I find this acceptable, maybe even preferable.