### PR TITLE
added rule so display identifier visible only for users

### DIFF
--- a/src/components/PeoplePicker/Principal.tsx
+++ b/src/components/PeoplePicker/Principal.tsx
@@ -78,7 +78,7 @@ export class Principal extends React.PureComponent<IPrincipalProps, IPrincipalSt
             } else if (displayIdentifier && type === PrincipalType.user) {
                 return `Email: ${email}\r\nUsername: ${displayIdentifier}`;
             }
-        } else if (displayIdentifier) {
+        } else if (displayIdentifier && type === PrincipalType.user) {
             return displayIdentifier;
         }
 


### PR DESCRIPTION
- added rule so we don't see SID as display identifier in tooltip