### PR TITLE
Adding prop isRowNotSelectable - TreeGrid, QuickGrid

### DIFF
--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -36,7 +36,7 @@ export interface IQuickGridProps {
     customCellRenderer?: (args: ICustomCellRendererArgs) => React.ReactNode;
     hasStaticColumns?: boolean;
     columnHeadersVisible?: boolean;
-    isRowNotSelectable?: boolean;
+    isRowSelectable?: boolean;
 }
 
 export interface ICustomCellRendererArgs {

--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -36,6 +36,7 @@ export interface IQuickGridProps {
     customCellRenderer?: (args: ICustomCellRendererArgs) => React.ReactNode;
     hasStaticColumns?: boolean;
     columnHeadersVisible?: boolean;
+    isRowNotSelectable?: boolean;
 }
 
 export interface ICustomCellRendererArgs {

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -35,7 +35,8 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         rowHeight: 28,
         tooltipsEnabled: true,
         actionsTooltip: 'Actions',
-        columnHeadersVisible: true
+        columnHeadersVisible: true,
+        isRowSelectable: true
     };
 
     private _finalGridRows: Array<any>;
@@ -423,7 +424,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
     }
 
     onMouseEnterCell = (rowIndex: number) => {
-        if (!this.props.isRowNotSelectable) {
+        if (this.props.isRowSelectable) {
             this._rowContextActionsHandler.markRowAsHovered(rowIndex);
         }
     }

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -423,7 +423,9 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
     }
 
     onMouseEnterCell = (rowIndex: number) => {
-        this._rowContextActionsHandler.markRowAsHovered(rowIndex);
+        if (!this.props.isRowNotSelectable) {
+            this._rowContextActionsHandler.markRowAsHovered(rowIndex);
+        }
     }
 
     renderBodyCell(columnIndex: number, key, rowIndex: number, rowData, style, onCellClick) {

--- a/src/components/TreeGrid/TreeGrid.Props.ts
+++ b/src/components/TreeGrid/TreeGrid.Props.ts
@@ -15,6 +15,7 @@ export interface ITreeGridProps {
     columnHeadersVisible?: boolean;
     filterString?: string;
     selectedNodeId?: number;
+    isRowNotSelectable?: boolean;
 }
 
 export interface ITreeGridState {    

--- a/src/components/TreeGrid/TreeGrid.Props.ts
+++ b/src/components/TreeGrid/TreeGrid.Props.ts
@@ -15,7 +15,7 @@ export interface ITreeGridProps {
     columnHeadersVisible?: boolean;
     filterString?: string;
     selectedNodeId?: number;
-    isRowNotSelectable?: boolean;
+    isNodeSelectable?: boolean;
 }
 
 export interface ITreeGridState {    

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -13,6 +13,9 @@ import { SpinnerType } from '../Spinner/Spinner.Props';
 import { IFinalTreeNode } from '../../models/TreeData';
 
 export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState> {
+    public static defaultProps = {
+        isNodeSelectable: true
+    };
 
     private _quickGrid: any;
     private _finalGridRows: Array<IFinalTreeNode>;
@@ -46,7 +49,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
     }
 
     componentWillMount() {
-        if (!this.props.isRowNotSelectable) {
+        if (this.props.isNodeSelectable) {
             if (this.state.selectedNodeId > 0) {
                 this._setSelectedNodeAndState(this.state.selectedNodeId);
             }
@@ -89,7 +92,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         this._quickGrid.updateColumnWidth(1, (old) => {
             return Math.max(old, getColumnMinWidth(this.state.columnsToDisplay[1]));
         });
-        if (this.props.selectedNodeId !== nextProps.selectedNodeId && !this.props.isRowNotSelectable) {
+        if (this.props.selectedNodeId !== nextProps.selectedNodeId && this.props.isNodeSelectable) {
             this._setSelectedNodeAndState(nextProps.selectedNodeId);
         }
     }
@@ -199,7 +202,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         let onCellClick = (e) => {
             // https://github.com/facebook/react/issues/1691 funky bussinese because of multiple mount points in the hover actions            
             // so stopPropagation and preventDefault do not work there, manually checking if row actions were clicked
-            if (!this.props.isRowNotSelectable) {
+            if (this.props.isNodeSelectable) {
                 if (e.currentTarget !== e.target) {
                     const rowActionsContainer = e.currentTarget.getElementsByClassName('hoverable-items-container__btn')[0];
                     if (rowActionsContainer && rowActionsContainer.contains(e.target)) {
@@ -314,7 +317,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
                 customRowSorter={this._getSortInfo}
                 columnSummaries={this.props.columnSummaries}
                 columnHeadersVisible={this.props.columnHeadersVisible}
-                isRowNotSelectable={this.props.isRowNotSelectable}
+                isRowSelectable={this.props.isNodeSelectable}
                 {...this._overscanProps}
             />
         );

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -46,8 +46,10 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
     }
 
     componentWillMount() {
-        if (this.state.selectedNodeId > 0) {
-            this._setSelectedNodeAndState(this.state.selectedNodeId);
+        if (!this.props.isRowNotSelectable) {
+            if (this.state.selectedNodeId > 0) {
+                this._setSelectedNodeAndState(this.state.selectedNodeId);
+            }
         }
     }
 
@@ -87,7 +89,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         this._quickGrid.updateColumnWidth(1, (old) => {
             return Math.max(old, getColumnMinWidth(this.state.columnsToDisplay[1]));
         });
-        if (this.props.selectedNodeId !== nextProps.selectedNodeId) {
+        if (this.props.selectedNodeId !== nextProps.selectedNodeId && !this.props.isRowNotSelectable) {
             this._setSelectedNodeAndState(nextProps.selectedNodeId);
         }
     }
@@ -197,14 +199,15 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         let onCellClick = (e) => {
             // https://github.com/facebook/react/issues/1691 funky bussinese because of multiple mount points in the hover actions            
             // so stopPropagation and preventDefault do not work there, manually checking if row actions were clicked
-            if (e.currentTarget !== e.target) {
-                const rowActionsContainer = e.currentTarget.getElementsByClassName('hoverable-items-container__btn')[0];
-                if (rowActionsContainer && rowActionsContainer.contains(e.target)) {
-                    return;
+            if (!this.props.isRowNotSelectable) {
+                if (e.currentTarget !== e.target) {
+                    const rowActionsContainer = e.currentTarget.getElementsByClassName('hoverable-items-container__btn')[0];
+                    if (rowActionsContainer && rowActionsContainer.contains(e.target)) {
+                        return;
+                    }
                 }
+                this._setSelectedNode(rowIndex, rowData);
             }
-
-            this._setSelectedNode(rowIndex, rowData);
         };
         onCellClick = rowData.isAsyncLoadingDummyNode ? undefined : onCellClick;
         if (rowData.isAsyncLoadingDummyNode && columnIndex === 1) {
@@ -278,7 +281,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         if (this.state.selectedNodeId === nodeData.nodeId) {
             return;
         }
-        this.setState({ selectedNodeId: nodeData.nodeId });        
+        this.setState({ selectedNodeId: nodeData.nodeId });
         if (this.props.onSelectedNodeChanged) {
             this.props.onSelectedNodeChanged(this._finalGridRows[rowIndex]);
         }
@@ -311,6 +314,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
                 customRowSorter={this._getSortInfo}
                 columnSummaries={this.props.columnSummaries}
                 columnHeadersVisible={this.props.columnHeadersVisible}
+                isRowNotSelectable={this.props.isRowNotSelectable}
                 {...this._overscanProps}
             />
         );


### PR DESCRIPTION
I added property isRowNotSelectable(boolean ) to TreeGrid.Props and QuickGrid.Props.

If you want to show data in TreeGrid but you don't want to select them onClick, you can set prop isRowNotSelectable as true. Also if you don't want that row has color on hover you can set the same prop in QuickGrid and nothing is going to happen on hover.