### PR TITLE
fix for crash when dialog overflows

### DIFF
--- a/src/components/CustomDateRange/CustomDateRange.scss
+++ b/src/components/CustomDateRange/CustomDateRange.scss
@@ -1,8 +1,6 @@
 @import '../../styles/variables.scss';
 
-.custom-date-range-dialog {
-    height: 481px;
-    
+.custom-date-range-dialog {    
     .custom-date-range-content {
         text-align: center;
 

--- a/src/components/Dialog/Dialog.scss
+++ b/src/components/Dialog/Dialog.scss
@@ -17,7 +17,7 @@ $dialog-section-padding: 20px;
         display: block;
         line-height: 100vh;
         text-align: center;
-        height: 100%;
+        height: 100vh;
     }
 
     &.is-animatingOpen {
@@ -100,7 +100,7 @@ $dialog-section-padding: 20px;
 
             .dialog-content {
                 display: flex;
-                max-height: calc(100% - 82px);
+                max-height: calc(100vh - 218px);
                 overflow-y: auto;
                 height: 100%;
                 padding-right: 20px;

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -50,10 +50,6 @@ export class Dialog extends CommonComponent<IDialogProps, IDialogState> {
         };
     }
 
-    public componentDidUpdate() {
-        this._checkDialogHeight(this._containerRef);
-    }
-
     public componentWillReceiveProps(newProps: IDialogProps) {
         // Opening the dialog
         if (newProps.isOpen && !this.state.isOpen) {
@@ -162,15 +158,6 @@ export class Dialog extends CommonComponent<IDialogProps, IDialogState> {
     @autobind
     private _getContainerRef(ref: HTMLDivElement) {
         this._containerRef = ref;
-        this._checkDialogHeight(ref);
-    }
-
-    private _checkDialogHeight(ref: HTMLDivElement) {
-        if (ref) {
-            if (Math.abs(window.innerHeight - ref.clientHeight) <= this.windowPadding) {
-                this.setState({ ...this.state, dialogClass: 'dialog-container' });
-            }
-        }
     }
 
     @autobind

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -112,7 +112,7 @@ export class Dropdown extends React.PureComponent<IDropdownProps, IDropdownState
             {this.props.displaySelection && this.props.showArrowIcon &&
                 <Icon className={dropdownIconClassName} iconName={arrowIcon}></Icon>
             }
-        </span>
+        </span>;
 
         return (
             <div ref="root" className="dropdown-root">


### PR DESCRIPTION
The React would break when the content in Dialog overflows. The culprit was the setState function in componentDidUpdate in Dialog.tsx. 
CSS is now used to determine the height of dialog instead of the JavaScript.
Fixed tslint warning in Dropdown component.