### PR TITLE
refactof LeftNavigation

### DIFF
--- a/src/components/LeftNavigation/LeftNavigation.Props.ts
+++ b/src/components/LeftNavigation/LeftNavigation.Props.ts
@@ -13,7 +13,6 @@ export interface ILeftNavigationProps {
     options: ILeftNavigationOption[];
     className?: string;
     onClick?: (ev?: React.MouseEvent<HTMLElement>, item?: ILeftNavigationOption) => void;
-    otherOptions?: ILeftNavigationOption[];
     expandCaptionsBehavior?: ExpandCaptionsBehaviorEnum;
 }
 
@@ -24,4 +23,10 @@ export interface ILeftNavigationOption {
     icon?: string;
     selected?: boolean;
     disabled?: boolean;
+    position?: LeftiNavigationOptionPositionEnum;
+}
+
+export enum LeftiNavigationOptionPositionEnum {
+    Up = 0,
+    Down = 1
 }

--- a/src/components/LeftNavigation/LeftNavigation.Props.ts
+++ b/src/components/LeftNavigation/LeftNavigation.Props.ts
@@ -23,10 +23,10 @@ export interface ILeftNavigationOption {
     icon?: string;
     selected?: boolean;
     disabled?: boolean;
-    position?: LeftiNavigationOptionPositionEnum;
+    position?: LeftNavigationOptionPositionEnum;
 }
 
-export enum LeftiNavigationOptionPositionEnum {
+export enum LeftNavigationOptionPositionEnum {
     Up = 0,
     Down = 1
 }

--- a/src/components/LeftNavigation/LeftNavigation.scss
+++ b/src/components/LeftNavigation/LeftNavigation.scss
@@ -60,11 +60,11 @@ $leftNavigation-collapsed-width: 45px;
                 }
             }
         }
-    }
 
-    .nav-item-other-options {
-        bottom: 15px;
-        position: absolute;
+        &.position-down {
+            bottom: 15px;
+            position: absolute;
+        }
     }
 
     &.expanded {

--- a/src/components/LeftNavigation/LeftNavigation.tsx
+++ b/src/components/LeftNavigation/LeftNavigation.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
-import { ILeftNavigationProps, ILeftNavigationOption, ExpandCaptionsBehaviorEnum } from './LeftNavigation.Props';
+import { ILeftNavigationProps, ILeftNavigationOption, ExpandCaptionsBehaviorEnum, LeftiNavigationOptionPositionEnum } from './LeftNavigation.Props';
 import { assign } from '../../utilities/object';
 import { findIndex } from '../../utilities/array';
 import { Icon } from '../../components/Icon/Icon';
@@ -19,8 +19,7 @@ export class LeftNavigation extends CommonComponent<ILeftNavigationProps, any> {
 
     public static defaultProps: Partial<ILeftNavigationProps> = {
         expandCaptionsBehavior: ExpandCaptionsBehaviorEnum.ShowCaptionsOnHover,
-        onClick: nullFunc,
-        otherOptions: []
+        onClick: nullFunc
     };
 
     constructor(props: ILeftNavigationProps) {
@@ -132,7 +131,8 @@ export class LeftNavigation extends CommonComponent<ILeftNavigationProps, any> {
                 'nav-item',
                 {
                     'disabled': option.disabled,
-                    'selected': this.state.selectedIndex === index
+                    'selected': this.state.selectedIndex === index,
+                    'position-down': option.position === LeftiNavigationOptionPositionEnum.Down ? true : false
                 });
 
             return (
@@ -141,28 +141,6 @@ export class LeftNavigation extends CommonComponent<ILeftNavigationProps, any> {
                     className={linkClasses}
                     title={option.text}
                     onClick={(ev) => this.onLinkClick(index, option, ev)}
-                >
-                    <a id={option.id}>
-                        <Icon iconName={option.icon} />
-                        <span>{option.text}</span>
-                    </a>
-                </div>
-            );
-        });
-
-        const otherChildrenItems = this.props.otherOptions.map((option, index) => {
-            const linkClasses = classNames(
-                'nav-item',
-                {
-                    'disabled': option.disabled
-                });
-
-            return (
-                <div
-                    key={option.id}
-                    className={linkClasses}
-                    title={option.text}
-                    onClick={(ev) => this.onOtherLinkClick(index, option, ev)}
                 >
                     <a id={option.id}>
                         <Icon iconName={option.icon} />
@@ -186,9 +164,6 @@ export class LeftNavigation extends CommonComponent<ILeftNavigationProps, any> {
                         </div>
                     }
                     {childrenItems}
-                    <div className="nav-item-other-options">
-                        {otherChildrenItems}
-                    </div>
                 </div>
             </div>
         );

--- a/src/components/LeftNavigation/LeftNavigation.tsx
+++ b/src/components/LeftNavigation/LeftNavigation.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
-import { ILeftNavigationProps, ILeftNavigationOption, ExpandCaptionsBehaviorEnum, LeftiNavigationOptionPositionEnum } from './LeftNavigation.Props';
+import { ILeftNavigationProps, ILeftNavigationOption, ExpandCaptionsBehaviorEnum, LeftNavigationOptionPositionEnum } from './LeftNavigation.Props';
 import { assign } from '../../utilities/object';
 import { findIndex } from '../../utilities/array';
 import { Icon } from '../../components/Icon/Icon';
@@ -132,7 +132,7 @@ export class LeftNavigation extends CommonComponent<ILeftNavigationProps, any> {
                 {
                     'disabled': option.disabled,
                     'selected': this.state.selectedIndex === index,
-                    'position-down': option.position === LeftiNavigationOptionPositionEnum.Down ? true : false
+                    'position-down': option.position === LeftNavigationOptionPositionEnum.Down ? true : false
                 });
 
             return (


### PR DESCRIPTION
In LeftNavigation.Props I removed otherOptions from props. 

I added position property in ILeftNavigationOption[]. You can define if your option is supposed to be down with LeftiNavigationOptionPositionEnum.Down.

[Example](https://monosnap.com/file/de3EAHepuruS5ziBZ22i4socIThRUL)

This refactor is because otherOptions weren't selected.
