### PR TITLE
Bug/left navigation down position css

### DIFF
--- a/examples/src/LeftNavigation.tsx
+++ b/examples/src/LeftNavigation.tsx
@@ -6,14 +6,16 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 import { LeftNavigation } from './../../src/components/LeftNavigation/LeftNavigation';
-import { ExpandCaptionsBehaviorEnum } from '../../src/index';
+import { ExpandCaptionsBehaviorEnum, LeftNavigationOptionPositionEnum } from '../../src/index';
 
 const options = [
     { text: 'Home page', id: 'Home', href: 'http://Acceleratio.net', icon: 'icon-help' },
     { text: 'Activity', id: 'Activity', href: '#1', disabled: true, icon: 'icon-account' },
     { text: 'News', id: 'News', href: '#2', icon: 'icon-add' },
     { text: 'Documents library', id: 'Documents', href: '#3', selected: true, icon: 'icon-alert' },
-    { text: 'Books', id: 'Books', href: '#4', icon: 'icon-trash' }
+    { text: 'Books', id: 'Books', href: '#4', icon: 'icon-trash', position: LeftNavigationOptionPositionEnum.Down },
+    { text: 'Documents library', id: 'documents', href: '#3', selected: false, icon: 'icon-alert', position: LeftNavigationOptionPositionEnum.Down  },
+    { text: 'Books', id: 'books', href: '#4', icon: 'icon-trash', position: LeftNavigationOptionPositionEnum.Down  }
 ];
 
 export class Index extends React.Component<any, any> {

--- a/examples/src/LeftNavigation.tsx
+++ b/examples/src/LeftNavigation.tsx
@@ -13,9 +13,7 @@ const options = [
     { text: 'Activity', id: 'Activity', href: '#1', disabled: true, icon: 'icon-account' },
     { text: 'News', id: 'News', href: '#2', icon: 'icon-add' },
     { text: 'Documents library', id: 'Documents', href: '#3', selected: true, icon: 'icon-alert' },
-    { text: 'Books', id: 'Books', href: '#4', icon: 'icon-trash', position: LeftNavigationOptionPositionEnum.Down },
-    { text: 'Documents library', id: 'documents', href: '#3', selected: false, icon: 'icon-alert', position: LeftNavigationOptionPositionEnum.Down  },
-    { text: 'Books', id: 'books', href: '#4', icon: 'icon-trash', position: LeftNavigationOptionPositionEnum.Down  }
+    { text: 'Books', id: 'Books', href: '#4', icon: 'icon-trash', position: LeftNavigationOptionPositionEnum.Down }
 ];
 
 export class Index extends React.Component<any, any> {

--- a/src/components/LeftNavigation/LeftNavigation.scss
+++ b/src/components/LeftNavigation/LeftNavigation.scss
@@ -60,12 +60,12 @@ $leftNavigation-collapsed-width: 45px;
                 }
             }
         }
-
-        &.position-down {
-            bottom: 15px;
-            position: absolute;
-        }
     }
+
+    .down-options {
+        bottom: 15px;
+        position: absolute;
+   }
 
     &.expanded {
         width: $leftNavigation-expanded-width;


### PR DESCRIPTION
Last update didn't work well if we had multiple options positioned down.

I corrected it by creating two arrays (one for upOptions and one for downOptions). After that I could put two different divs and manage css so it can show my icons correctly.

I needed to change that selectedIndex, it is now selectedId because if we have two arrays it didn't work well also (it was selecting 2 options at time).