### PR TITLE
Feat/adding prop to principal

### DIFF
--- a/src/components/PeoplePicker/Principal.Props.ts
+++ b/src/components/PeoplePicker/Principal.Props.ts
@@ -18,6 +18,7 @@ export interface IPrincipal {
     displayIdentifier?: string;
     email: string;
     type: PrincipalType;
+    isUnifiedSecurityGroup: boolean;
 }
 
 export enum PrincipalType {

--- a/src/components/PeoplePicker/Principal.Props.ts
+++ b/src/components/PeoplePicker/Principal.Props.ts
@@ -18,7 +18,7 @@ export interface IPrincipal {
     displayIdentifier?: string;
     email: string;
     type: PrincipalType;
-    isUnifiedSecurityGroup: boolean;
+    isUnifiedSecurityGroup?: boolean;
 }
 
 export enum PrincipalType {


### PR DESCRIPTION
I added property  isUnifiedSecurityGroup?: boolean; to IPrincipal, because we have method     mapPrincipalToIconClass?: (IPrincipal) => string; which we use for mapping icon className, and based on this property one icon has two different classNames.