### PR TITLE
Expand to selected if collapsed

### DIFF
--- a/examples/src/TreeGrid.tsx
+++ b/examples/src/TreeGrid.tsx
@@ -12,7 +12,7 @@ import '../../src/components/TreeFilter/TreeFilter.scss'; // used for react-resi
 import '../../src/components/Label/Label.scss';
 import { updateTree, rebuildTree } from '../../src/utilities/rebuildTree';
 import './../../src/components/Icon/symbol-defs.svg';
-import { autobind, QuickGridActions, QuickGridActionsBehaviourEnum, Search, TreeDataSource } from '../../src/index';
+import { autobind, QuickGridActions, QuickGridActionsBehaviourEnum, Search, TreeDataSource, Label } from '../../src/index';
 import { IFinalTreeNode, TreeNode } from '../../src/models/TreeData';
 
 
@@ -27,7 +27,8 @@ export class Index extends React.Component<any, any> {
         data: getTreeGridData(0),
         columns: gridColumns1,
         selectedData: 1,
-        searchText: ''
+        searchText: '',
+        selectedNode: 1
     };
 
     gridActions: QuickGridActions = {
@@ -47,9 +48,26 @@ export class Index extends React.Component<any, any> {
     }
 
     searchQueryChanged = (value: string) => {
-        this.setState(prev => ({            
+        this.setState(prev => ({
             searchText: value
         }));
+    }
+
+    scrollTo = (ev) => {
+        let val = ev.target.value;
+        if (ev.target.value.trim() === '') {
+            val = 1;
+        }
+
+        this.setState({
+            selectedNode: Number(val)
+        });
+    }
+
+    onSelectedNodeChanged = (selectedNode: IFinalTreeNode) => {
+        this.setState({
+            selectedNode: selectedNode.nodeId
+        });
     }
 
     prev: any;
@@ -72,6 +90,8 @@ export class Index extends React.Component<any, any> {
                     />
                 </div>
                 <Button onClick={this.refreshData}>Refresh data</Button>
+                <Label>Select item:</Label>
+                <input type="number" onChange={this.scrollTo} />
                 <div style={{ width: 250, paddingTop: 10 }}><Search value={this.state.searchText} labelText="Search nodes..." onChange={this.searchQueryChanged} /></div>
                 <Resizable width={1000} height={700} >
                     <div className="viewport-height" style={{ height: '100%' }} >
@@ -82,6 +102,8 @@ export class Index extends React.Component<any, any> {
                             onLazyLoadChildNodes={this.onLoadChildNodes}
                             columnSummaries={columnSummaries}
                             filterString={this.state.searchText}
+                            onSelectedNodeChanged={this.onSelectedNodeChanged}
+                            selectedNodeId={this.state.selectedNode}
                         />
                     </div>
                 </Resizable>

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -3,7 +3,7 @@ import * as ReactDOM from 'react-dom';
 import * as classNames from 'classnames';
 import { ITreeGridProps, ITreeGridState } from './TreeGrid.Props';
 
-import { getTreeRowsSelector } from './treeGridDataSelectors';
+import { getTreeRowsSelector } from './TreeGridDataSelectors';
 import { Icon } from '../Icon/Icon';
 import { QuickGrid, IQuickGridProps, SortDirection, GridColumn, ICustomCellRendererArgs, getColumnMinWidth } from '../QuickGrid';
 import { DataTypeEnum } from '../QuickGrid/QuickGrid.Props';
@@ -43,7 +43,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
             structureRequestChangeId: 0,
             selectedNodeId: props.selectedNodeId
         };
-        const result = getTreeRowsSelector(this.state, props);
+        const result = getTreeRowsSelector(this.state, props, props);
         this._finalGridRows = result.data;
         this._maxExpandedLevel = result.maxExpandedLevel;
     }
@@ -86,7 +86,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
     }
 
     public componentWillUpdate(nextProps, nextState) {
-        const result = getTreeRowsSelector(nextState, nextProps);
+        const result = getTreeRowsSelector(nextState, nextProps, this.props);
         this._finalGridRows = result.data;
         this._maxExpandedLevel = result.maxExpandedLevel;
         this._quickGrid.updateColumnWidth(1, (old) => {
@@ -201,7 +201,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
 
         let columnElement: any;
         let onCellClick = (e) => {
-            // https://github.com/facebook/react/issues/1691 funky bussinese because of multiple mount points in the hover actions            
+            // https://github.com/facebook/react/issues/1691 funky bussinese because of multiple mount points in the hover actions
             // so stopPropagation and preventDefault do not work there, manually checking if row actions were clicked
             if (this.props.isNodeSelectable) {
                 if (e.currentTarget !== e.target) {


### PR DESCRIPTION
When selectedNodeId prop is passed from outside of component and its parents were collapsed, node was selected but not showed. This is the fix for that behaviour, so now all nodes in path to selected node will be expanded. #262 