### PR TITLE
Async load rendering can now be performed even if the node already has children

### DIFF
--- a/src/components/TreeGrid/TreeGridDataSelectors.ts
+++ b/src/components/TreeGrid/TreeGridDataSelectors.ts
@@ -183,7 +183,7 @@ export function flatten(tree, resultArray: Array<IFinalTreeNode>, level: number 
         if (child.children && child.children.length > 0 && (child.isExpanded || child.descendantSatisfiesFilterCondition) && !child.isLazyChildrenLoadInProgress) {
             thisChildDepth = flatten(child.children, resultArray, level, idsInPath);
 
-        } else if (child.isLazyChildrenLoadInProgress) {
+        } else if (child.isExpanded && child.isLazyChildrenLoadInProgress) {
             resultArray.push({
                 nodeLevel: child.nodeLevel + 1,
                 nodeId: -child.nodeId,

--- a/src/components/TreeGrid/TreeGridDataSelectors.ts
+++ b/src/components/TreeGrid/TreeGridDataSelectors.ts
@@ -180,10 +180,10 @@ export function flatten(tree, resultArray: Array<IFinalTreeNode>, level: number 
             child.isExpanded = true;
         }
 
-        if (child.children && child.children.length > 0 && (child.isExpanded || child.descendantSatisfiesFilterCondition)) {
+        if (child.children && child.children.length > 0 && (child.isExpanded || child.descendantSatisfiesFilterCondition) && !child.isLazyChildrenLoadInProgress) {
             thisChildDepth = flatten(child.children, resultArray, level, idsInPath);
 
-        } else if (child.hasChildren && child.isExpanded && (!child.children || child.children.length === 0)) {
+        } else if (child.isLazyChildrenLoadInProgress) {
             resultArray.push({
                 nodeLevel: child.nodeLevel + 1,
                 nodeId: -child.nodeId,


### PR DESCRIPTION
Async load rendering can now be performed even if the node already has children