### PR TITLE
Added in quick grid to pass delay property on dropdown

### DIFF
--- a/src/components/QuickGrid/QuickGridRowContextActionsHandler.tsx
+++ b/src/components/QuickGrid/QuickGridRowContextActionsHandler.tsx
@@ -157,6 +157,7 @@ export class QuickGridRowContextActionsHandler extends React.PureComponent<IQuic
                     options={actionOptions}
                     onMenuToggle={onMenuToggle}
                     onClosed={() => onMenuToggle(false)}
+                    delayMs={this.props.delayMs}
                 />);
         } else {
             elements = actions.map(mapAction);


### PR DESCRIPTION
I added in quick grid to pass delay property on dropdown (to be same for all components in quick grid in any other case if we don't want to have delay 500ms)