### PR TITLE
Feat/enable group selection toggle virtualized tree view

### DIFF
--- a/examples/MockData/treeFilterElements.ts
+++ b/examples/MockData/treeFilterElements.ts
@@ -1,6 +1,6 @@
 import { TreeItem } from '../../src';
 
-const RANDOM_WORDS = ['abstrusity', 'advertisable', 'bellwood', 'benzole', 'disputative', 'djilas', 'ebracteate', 'zonary'];
+const RANDOM_WORDS = ['abstrusity', 'advertisable', 'bellwood', 'benzole', 'disputative', 'djilas', 'ebracteate', 'zonary', 'chromosome', 'downcast', 'evil', 'cottage', 'adopter', 'coal', 'locust', 'crackpot', 'abstinence', 'joypop'];
 
 export function createFlatList(numOfItems) {
     let data = [];

--- a/examples/MockData/treeFilterElements.ts
+++ b/examples/MockData/treeFilterElements.ts
@@ -1,3 +1,5 @@
+import { TreeItem } from '../../src';
+
 const RANDOM_WORDS = ['abstrusity', 'advertisable', 'bellwood', 'benzole', 'disputative', 'djilas', 'ebracteate', 'zonary'];
 
 export function createFlatList(numOfItems) {
@@ -15,6 +17,43 @@ export function getSelectedIds(numOfItems) {
         ids.push(i.toString());
     }
     return ids;
+}
+
+// Function to fill TreeView Data which I used to test the performance. Doesn't hurt if it stays here
+let id = 0;
+
+export function createData(hierarchy: Array<number>, depth = 0) {
+    const data: Array<TreeItem> = [];
+
+    if (depth < hierarchy.length) {
+        for (let i = 0; i < hierarchy[depth]; i++) {
+            const name = RANDOM_WORDS[Math.floor(Math.random() * RANDOM_WORDS.length)];
+            const identifier = id++;
+            const treeItem: TreeItem = {
+                expanded: true,
+                id: identifier + '',
+                value: identifier + ' ' + name,
+                iconName: Math.random() > 0.8 ? 'icon-edit_user' : '',
+                iconClassName: 'color',
+                hasChildren: depth + 1 < hierarchy.length,
+                hoverOverBtn: [{
+                    iconName: 'icon-edit',
+                    // tslint:disable-next-line:no-console
+                    callback: (item) => console.log(item.id),
+                    tooltip: { content: 'This is tooltip! This is tooltip! This is tooltip!' }
+                },
+                {
+                    iconName: 'icon-trash',
+                    // tslint:disable-next-line:no-console
+                    callback: (item) => console.log(item)
+                }],
+                children: createData(hierarchy, depth + 1)
+            };
+            data.push(treeItem);
+        }
+    }
+
+    return data;
 }
 
 export function createRandomizedData(numOfItems, maxDepth) {
@@ -38,7 +77,7 @@ export function createRandomizedData(numOfItems, maxDepth) {
                 iconName: 'icon-edit',
                 // tslint:disable-next-line:no-console
                 callback: (item) => console.log(item.id),
-                tooltip: {content: 'This is tooltip! This is tooltip! This is tooltip!' }
+                tooltip: { content: 'This is tooltip! This is tooltip! This is tooltip!' }
             },
             {
                 iconName: 'icon-trash',
@@ -55,7 +94,7 @@ export function createRandomizedData(numOfItems, maxDepth) {
     return data;
 }
 
-export function createAsyncLoadRandomizedData(numOfItems, maxDepth) {    
+export function createAsyncLoadRandomizedData(numOfItems, maxDepth) {
     const createRandomizedItem = (key, depth) => {
         let children = [];
         let hasChildren;

--- a/examples/src/TreeFilter.tsx
+++ b/examples/src/TreeFilter.tsx
@@ -247,7 +247,7 @@ export class Index extends React.Component<any, DemoState> {
                     defaultSelection={FilterSelectionEnum.All}
                     // tslint:disable-next-line:no-string-literal
                     filterSelection={this.state.filterStates['f10']}
-                    isGroupSelectableOnMultiSelect={false}
+                    enableRecursiveSelection={false}
                     hasTitleBorder={true}
                     showButtons={false}
                     onValuesSelected={this.onValuesSelected}

--- a/examples/src/TreeFilter.tsx
+++ b/examples/src/TreeFilter.tsx
@@ -6,16 +6,17 @@ import { rebuildTree, updateTree, expandOrCollapseTreeItem, expandOrCollapseAsyn
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { TreeFilter, IFilterSelection, FilterSelectionEnum, VirtualizedTreeView, TreeItem } from '../../src/components/TreeFilter';
-import { createFlatList, createRandomizedData, getSelectedIds, createAsyncLoadRandomizedData, createCustomTooltipContentRandomizedData } from '../MockData/treeFilterElements';
+import { createFlatList, createRandomizedData, getSelectedIds, createAsyncLoadRandomizedData, createCustomTooltipContentRandomizedData, createData } from '../MockData/treeFilterElements';
 import { Button } from '../../src/components/Button/Button';
 import { ILookupTable } from '../../src/components/TreeFilter/TreeItemOperators';
 import { Spinner } from '../../src/components/Spinner/Spinner';
 import { SpinnerType } from '../../src/components/Spinner';
 
 interface DemoState {
-    filterStates: { [id: string]: IFilterSelection };    
+    filterStates: { [id: string]: IFilterSelection };
     asyncTreeData: TreeItem[];
     treeData: TreeItem[];
+    treeData2: TreeItem[];
 }
 
 const deeperTreeData = createRandomizedData(50, 4);
@@ -28,9 +29,10 @@ export class Index extends React.Component<any, DemoState> {
         super(props);
         const asyncTreeData = createAsyncLoadRandomizedData(1000, 4);
         this.state = {
-            filterStates: {},            
+            filterStates: {},
             asyncTreeData: asyncTreeData,
-            treeData: createRandomizedData(2000, 2)
+            treeData: createRandomizedData(2000, 2),
+            treeData2: createData([2, 4])
         };
     }
 
@@ -48,40 +50,40 @@ export class Index extends React.Component<any, DemoState> {
         console.log('Save clicked!', newFilters);
     }
 
-    onAsyncTreeItemExpand = (treeItem: TreeItem, lookupTableGetter) => {        
-        
-        
+    onAsyncTreeItemExpand = (treeItem: TreeItem, lookupTableGetter) => {
+
+
 
         expandOrCollapseAsyncTreeItem(() => this.state.asyncTreeData,
-         treeItem,
-          lookupTableGetter, 
-          (roots) => {
-            this.setState({
-                ...this.state,
-                asyncTreeData: roots
-            });
+            treeItem,
+            lookupTableGetter,
+            (roots) => {
+                this.setState({
+                    ...this.state,
+                    asyncTreeData: roots
+                });
 
-         },
-        
-          () => {
-             return new Promise<TreeItem[]>((resolve) => {
-                setTimeout(() => {
-                    const randomNumber = (Math.random() * 100).toFixed(0);                    
-                    const children = [{
-                        id: treeItem.id + '-' + '1',
-                        value: 'asyncly loaded ' + randomNumber,
-                        expanded: false
-                    }, {
-                        id: treeItem.id + '-' + '2',
-                        value: 'asyncly loaded 2',
-                        expanded: false
-                    }];
+            },
 
-                    resolve(children);                            
-                }, 3000);
-             });
-          }
-        );        
+            () => {
+                return new Promise<TreeItem[]>((resolve) => {
+                    setTimeout(() => {
+                        const randomNumber = (Math.random() * 100).toFixed(0);
+                        const children = [{
+                            id: treeItem.id + '-' + '1',
+                            value: 'asyncly loaded ' + randomNumber,
+                            expanded: false
+                        }, {
+                            id: treeItem.id + '-' + '2',
+                            value: 'asyncly loaded 2',
+                            expanded: false
+                        }];
+
+                        resolve(children);
+                    }, 3000);
+                });
+            }
+        );
     }
 
     private onItemExpand = (treeItem: TreeItem, lookupTableGetter) => {
@@ -214,7 +216,7 @@ export class Index extends React.Component<any, DemoState> {
                     showStatusBar={false}
                     validated={false}
                 />
-                <br/><br/>
+                <br /><br />
                 <TreeFilter
                     title="Custom tooltip content Icon"
                     filterId={'f3'}
@@ -235,6 +237,21 @@ export class Index extends React.Component<any, DemoState> {
                         bottomLeft: true,
                         topLeft: false
                     }}
+                />
+
+                <br /><br />
+                <p>This TreeFilter has the isGroupSelectableOnMultiSelect prop set to true</p>
+                <TreeFilter
+                    filterId={'f10'}
+                    items={this.state.treeData2}
+                    defaultSelection={FilterSelectionEnum.All}
+                    // tslint:disable-next-line:no-string-literal
+                    filterSelection={this.state.filterStates['f10']}
+                    isGroupSelectableOnMultiSelect={false}
+                    hasTitleBorder={true}
+                    showButtons={false}
+                    onValuesSelected={this.onValuesSelected}
+                    onSave={this.onSave}
                 />
             </div>
         );

--- a/src/components/TreeFilter/TreeFilter.Props.ts
+++ b/src/components/TreeFilter/TreeFilter.Props.ts
@@ -29,7 +29,7 @@ export interface ITreeFilterProps {
     hasSearch?: boolean;
     isSingleSelect?: boolean;
     isGroupSelectableOnSingleSelect?: boolean;
-    isGroupSelectableOnMultiSelect?: boolean;
+    enableRecursiveSelection?: boolean;
     itemsAreFlatList?: boolean;
     onValuesSelected?: (filterId: string, filterSelection: IFilterSelection) => void;
     defaultSelection?: FilterSelectionEnum;
@@ -71,7 +71,7 @@ export const defaultTreeFilterProps: Partial<ITreeFilterProps> = {
     isSingleSelect: false,
     itemsAreFlatList: false,
     isGroupSelectableOnSingleSelect: false,
-    isGroupSelectableOnMultiSelect: true,
+    enableRecursiveSelection: true,
     directionalHint: DirectionalHint.bottomRightEdge,
     filterSelection: { type: FilterSelectionEnum.None, selectedIDs: [] },
     width: 300,

--- a/src/components/TreeFilter/TreeFilter.Props.ts
+++ b/src/components/TreeFilter/TreeFilter.Props.ts
@@ -29,6 +29,7 @@ export interface ITreeFilterProps {
     hasSearch?: boolean;
     isSingleSelect?: boolean;
     isGroupSelectableOnSingleSelect?: boolean;
+    isGroupSelectableOnMultiSelect?: boolean;
     itemsAreFlatList?: boolean;
     onValuesSelected?: (filterId: string, filterSelection: IFilterSelection) => void;
     defaultSelection?: FilterSelectionEnum;
@@ -70,6 +71,7 @@ export const defaultTreeFilterProps: Partial<ITreeFilterProps> = {
     isSingleSelect: false,
     itemsAreFlatList: false,
     isGroupSelectableOnSingleSelect: false,
+    isGroupSelectableOnMultiSelect: true,
     directionalHint: DirectionalHint.bottomRightEdge,
     filterSelection: { type: FilterSelectionEnum.None, selectedIDs: [] },
     width: 300,

--- a/src/components/TreeFilter/VirtualizedTreeView.Props.ts
+++ b/src/components/TreeFilter/VirtualizedTreeView.Props.ts
@@ -34,7 +34,7 @@ export const defaultTreeProps: Partial<IVirtualizedTreeViewProps> = {
     isSingleSelect: false,
     itemsAreFlatList: false,
     isGroupSelectableOnSingleSelect: false,
-    isGroupSelectableOnMultiSelect: false,
+    isGroupSelectableOnMultiSelect: true,
     onValuesSelected: () => { },
     filterSelection: { type: FilterSelectionEnum.None, selectedIDs: [] },
     defaultSelection: FilterSelectionEnum.None,

--- a/src/components/TreeFilter/VirtualizedTreeView.Props.ts
+++ b/src/components/TreeFilter/VirtualizedTreeView.Props.ts
@@ -14,7 +14,7 @@ export interface IVirtualizedTreeViewProps {
     onSave?: () => void;
     onCancel?: () => void;
     isGroupSelectableOnSingleSelect?: boolean;
-    isGroupSelectableOnMultiSelect?: boolean;
+    enableRecursiveSelection?: boolean;
     itemsAreFlatList?: boolean;
     onValuesSelected?: (filterId: string, filterSelection: IFilterSelection) => void;
     defaultSelection?: FilterSelectionEnum;
@@ -34,7 +34,7 @@ export const defaultTreeProps: Partial<IVirtualizedTreeViewProps> = {
     isSingleSelect: false,
     itemsAreFlatList: false,
     isGroupSelectableOnSingleSelect: false,
-    isGroupSelectableOnMultiSelect: true,
+    enableRecursiveSelection: true,
     onValuesSelected: () => { },
     filterSelection: { type: FilterSelectionEnum.None, selectedIDs: [] },
     defaultSelection: FilterSelectionEnum.None,

--- a/src/components/TreeFilter/VirtualizedTreeView.Props.ts
+++ b/src/components/TreeFilter/VirtualizedTreeView.Props.ts
@@ -14,6 +14,7 @@ export interface IVirtualizedTreeViewProps {
     onSave?: () => void;
     onCancel?: () => void;
     isGroupSelectableOnSingleSelect?: boolean;
+    isGroupSelectableOnMultiSelect?: boolean;
     itemsAreFlatList?: boolean;
     onValuesSelected?: (filterId: string, filterSelection: IFilterSelection) => void;
     defaultSelection?: FilterSelectionEnum;
@@ -22,7 +23,7 @@ export interface IVirtualizedTreeViewProps {
     searchQuery?: string;
     allItemIdsGetter?: (items?: Array<TreeItem>) => ReadonlyArray<string>;
     lookupTableGetter?: (items?: Array<TreeItem>) => any;
-    onItemExpand?: (item?: TreeItem, lookupTableGetter?: () => TreeLookups ) => void;
+    onItemExpand?: (item?: TreeItem, lookupTableGetter?: () => TreeLookups) => void;
     showSelectAll?: boolean;
     showStatusBar?: boolean;
 }
@@ -33,6 +34,7 @@ export const defaultTreeProps: Partial<IVirtualizedTreeViewProps> = {
     isSingleSelect: false,
     itemsAreFlatList: false,
     isGroupSelectableOnSingleSelect: false,
+    isGroupSelectableOnMultiSelect: false,
     onValuesSelected: () => { },
     filterSelection: { type: FilterSelectionEnum.None, selectedIDs: [] },
     defaultSelection: FilterSelectionEnum.None,

--- a/src/components/TreeFilter/VirtualizedTreeView.tsx
+++ b/src/components/TreeFilter/VirtualizedTreeView.tsx
@@ -418,7 +418,10 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
     private getNewCheckedItems(changedTreeItem: TreeItem, checkedItemIds, wasChecked): CheckResult {
         let itemsToChange = [];
         let branchesToCheck = [];
-        if (this.state.searchText === '') {
+
+        if (!this.props.isGroupSelectableOnMultiSelect) {
+            itemsToChange.push(changedTreeItem.id);
+        } else if (this.state.searchText === '') {
             itemsToChange = ItemOperator.getAllChildrenIds(changedTreeItem);
             if (itemHasChildren(changedTreeItem)) {
                 branchesToCheck.push({ id: changedTreeItem.id, depth: 0 });
@@ -510,6 +513,21 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
     }
 
     private setNewSelectedState(allChecked: boolean, newChecked, newPartiallyChecked) {
+        if (!this.props.isGroupSelectableOnMultiSelect) {
+            let newType = FilterSelectionEnum.None;
+            let selectedIDs = [];
+
+            if (newChecked.length === this.allItemIds.length) {
+                newType = FilterSelectionEnum.All;
+            } else if (newChecked.length > 0) {
+                selectedIDs = newChecked;
+                newType = FilterSelectionEnum.Selected;
+            }
+
+            this.props.onValuesSelected(this.props.filterId, { type: newType, selectedIDs: selectedIDs });
+            return;
+        }
+
         const allSelected = allChecked || this.areAllItemsSelected(newChecked) === CheckStatus.Checked;
         if (allSelected) {
             this.props.onValuesSelected(this.props.filterId, { type: FilterSelectionEnum.All, selectedIDs: [] });

--- a/src/components/TreeFilter/VirtualizedTreeView.tsx
+++ b/src/components/TreeFilter/VirtualizedTreeView.tsx
@@ -234,7 +234,7 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
                 return <SingleSelectItemWithButtons />;
             } else {
                 let checked = itemChecked ? CheckStatus.Checked : CheckStatus.NotChecked;
-                if (this.isItemInList(this.state.partiallyCheckedItemIds, treeItem) && this.props.isGroupSelectableOnMultiSelect) {
+                if (this.isItemInList(this.state.partiallyCheckedItemIds, treeItem) && this.props.enableRecursiveSelection) {
                     checked = CheckStatus.ChildChecked;
                 }
 
@@ -367,7 +367,7 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
             }
         } else { // tree structure
             if (this.state.searchText === '') {
-                if (!this.props.isGroupSelectableOnMultiSelect) {
+                if (!this.props.enableRecursiveSelection) {
                     this.setNewSelectedState(!allSelected, [], []);
                 } else if (allSelected) {
                     this.setNewSelectedState(false, [], []);
@@ -391,7 +391,7 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
                     branchesToCheck = branchesToCheck.concat(leafsAndBranches.Branches);
                 }
                 // filtriraj flat vrijednosti
-                /*if (!this.props.isGroupSelectableOnMultiSelect) {
+                /*if (!this.props.enableRecursiveSelection ) {
                     itemsToChange = _.without<any>(itemsToChange, ...ItemOperator.getAllItemIds(filteredItems));
                 }*/
 
@@ -426,7 +426,7 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
         let itemsToChange = [];
         let branchesToCheck = [];
 
-        if (!this.props.isGroupSelectableOnMultiSelect) {
+        if (!this.props.enableRecursiveSelection) {
             itemsToChange.push(changedTreeItem.id);
             const parent = this.parentLookup[changedTreeItem.id];
             if (parent !== undefined) {
@@ -489,7 +489,7 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
             isPartiallyChecked = !isChecked && isPartiallyChecked; // item cannot be checked and partial
 
             // Add/Remove from lists
-            if (this.props.isGroupSelectableOnMultiSelect) {
+            if (this.props.enableRecursiveSelection) {
                 this.modifyListForItem(newChecked, item.id, isChecked);
             }
             this.modifyListForItem(newPartiallyChecked, item.id, isPartiallyChecked);
@@ -526,7 +526,7 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
     }
 
     private setNewSelectedState(allChecked: boolean, newChecked, newPartiallyChecked) {
-        if (!this.props.isGroupSelectableOnMultiSelect) {
+        if (!this.props.enableRecursiveSelection) {
             let newType = FilterSelectionEnum.None;
             let selectedIDs = [];
 

--- a/src/components/TreeFilter/VirtualizedTreeView.tsx
+++ b/src/components/TreeFilter/VirtualizedTreeView.tsx
@@ -234,7 +234,7 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
                 return <SingleSelectItemWithButtons />;
             } else {
                 let checked = itemChecked ? CheckStatus.Checked : CheckStatus.NotChecked;
-                if (this.isItemInList(this.state.partiallyCheckedItemIds, treeItem)) {
+                if (this.isItemInList(this.state.partiallyCheckedItemIds, treeItem) && this.props.isGroupSelectableOnMultiSelect) {
                     checked = CheckStatus.ChildChecked;
                 }
 
@@ -367,7 +367,9 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
             }
         } else { // tree structure
             if (this.state.searchText === '') {
-                if (allSelected) {
+                if (!this.props.isGroupSelectableOnMultiSelect) {
+                    this.setNewSelectedState(!allSelected, [], []);
+                } else if (allSelected) {
                     this.setNewSelectedState(false, [], []);
                 } else {
                     this.setNewSelectedState(true, [], []);
@@ -382,11 +384,16 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
 
                 let itemsToChange = [];
                 let branchesToCheck = [];
+
                 for (let item of filteredItems) {
                     const leafsAndBranches = ItemOperator.getAllLeafsAndBranches(item, this.itemLookup[item.id]);
                     itemsToChange = itemsToChange.concat(leafsAndBranches.Leafs);
                     branchesToCheck = branchesToCheck.concat(leafsAndBranches.Branches);
                 }
+                // filtriraj flat vrijednosti
+                /*if (!this.props.isGroupSelectableOnMultiSelect) {
+                    itemsToChange = _.without<any>(itemsToChange, ...ItemOperator.getAllItemIds(filteredItems));
+                }*/
 
                 let newCheckedItems: Array<string> = [];
                 if (allFilteredChecked) {
@@ -421,6 +428,10 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
 
         if (!this.props.isGroupSelectableOnMultiSelect) {
             itemsToChange.push(changedTreeItem.id);
+            const parent = this.parentLookup[changedTreeItem.id];
+            if (parent !== undefined) {
+                branchesToCheck.push({ id: parent.id, depth: 0 });
+            }
         } else if (this.state.searchText === '') {
             itemsToChange = ItemOperator.getAllChildrenIds(changedTreeItem);
             if (itemHasChildren(changedTreeItem)) {
@@ -478,7 +489,9 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
             isPartiallyChecked = !isChecked && isPartiallyChecked; // item cannot be checked and partial
 
             // Add/Remove from lists
-            this.modifyListForItem(newChecked, item.id, isChecked);
+            if (this.props.isGroupSelectableOnMultiSelect) {
+                this.modifyListForItem(newChecked, item.id, isChecked);
+            }
             this.modifyListForItem(newPartiallyChecked, item.id, isPartiallyChecked);
 
             const parent = this.parentLookup[checkItem.id];
@@ -517,7 +530,7 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
             let newType = FilterSelectionEnum.None;
             let selectedIDs = [];
 
-            if (newChecked.length === this.allItemIds.length) {
+            if (newChecked.length === this.allItemIds.length || allChecked) {
                 newType = FilterSelectionEnum.All;
             } else if (newChecked.length > 0) {
                 selectedIDs = newChecked;
@@ -525,6 +538,7 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
             }
 
             this.props.onValuesSelected(this.props.filterId, { type: newType, selectedIDs: selectedIDs });
+            this.setState(prevState => ({ ...prevState, partiallyCheckedItemIds: newPartiallyChecked }));
             return;
         }
 


### PR DESCRIPTION
A new prop (isGroupSelectableOnMultiSelect) was added. Its purpose is enabling the user to check a parent item without automatically selecting its child items. This feature is disabled by default. I needed this functionality for my MegaFilter, hope it turns out to be useful somewhere else too.

The select all button functionality isn't quite done yet. The problem is only when there is a search string provided.