### PR TITLE
Fix for when scrolling to last row

### DIFF
--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -79,7 +79,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
             row = index;
         }
 
-        if (index !== undefined && index > rowCount) {
+        if (index !== undefined && index >= rowCount) {
             row = rowCount - 1;
         }
 


### PR DESCRIPTION
Passing nodeId from the last added row now scrolls to it properly