### PR TITLE
Feat/grid bool column type

### DIFF
--- a/examples/MockData/gridData.ts
+++ b/examples/MockData/gridData.ts
@@ -1,4 +1,4 @@
-import { GridColumn, DataTypeEnum, SortDirection } from '../../src/components/QuickGrid/QuickGrid.Props';
+import { GridColumn, DataTypeEnum, SortDirection, BoolFormatTypeEnum } from '../../src/components/QuickGrid/QuickGrid.Props';
 import { TreeNode, TreeDataSource } from '../../src/models/TreeData';
 
 
@@ -18,6 +18,7 @@ export interface GridData extends TreeNode {
     Animal: string;
     Mixed: string | number;
     Numbers: number;
+    IsUpdated: boolean;
 }
 
 let totalItems = 0;
@@ -58,7 +59,8 @@ export const generateTreeNode = () => {
         Color:  randomLower(RANDOM_Color[Math.floor(Math.random() * RANDOM_Color.length)]),
         Animal: RANDOM_Animal[Math.floor(Math.random() * RANDOM_Animal.length)],
         Mixed: RANDOM_Mix[Math.floor(Math.random() * RANDOM_Mix.length)],
-        Numbers: Math.floor(Math.random() * 30)
+        Numbers: Math.floor(Math.random() * 30),
+        IsUpdated: Math.random() >= 0.5
 
     };
 };
@@ -125,6 +127,12 @@ export const gridColumns1: Array<GridColumn> = [
         valueMember: 'Numbers',
         headerText: 'Numbers',
         width: 100
+    }, {
+        valueMember: 'IsUpdated',
+        headerText: 'Is Updated',
+        width: 100,
+        dataType: DataTypeEnum.Boolean,
+        boolFormatType: BoolFormatTypeEnum.Both
     }
 ];
 
@@ -156,6 +164,12 @@ export const gridColumns2: Array<GridColumn> = [
         valueMember: 'Numbers',
         headerText: 'Numbers',
         width: 100
+    }, {
+        valueMember: 'IsUpdated',
+        headerText: 'Is Updated',
+        width: 100,
+        dataType: DataTypeEnum.Boolean,
+        boolFormatType: BoolFormatTypeEnum.Both
     }
 ];
 
@@ -181,7 +195,8 @@ export function getGridData(numberOfElements) {
                 Color:  RANDOM_Color[Math.floor(Math.random() * RANDOM_Color.length)],
                 Animal: RANDOM_Animal[Math.floor(Math.random() * RANDOM_Animal.length)],
                 Mixed: RANDOM_Mix[Math.floor(Math.random() * RANDOM_Mix.length)],
-                Numbers: Math.floor(Math.random() * 30)
+                Numbers: Math.floor(Math.random() * 30),
+                IsUpdated: Math.random() >= 0.5
             }
         );
     }

--- a/examples/MockData/gridData.ts
+++ b/examples/MockData/gridData.ts
@@ -132,7 +132,7 @@ export const gridColumns1: Array<GridColumn> = [
         headerText: 'Is Updated',
         width: 100,
         dataType: DataTypeEnum.Boolean,
-        boolFormatType: BoolFormatTypeEnum.Both
+        boolFormatType: BoolFormatTypeEnum.CheckmarkAndCross
     }
 ];
 
@@ -169,7 +169,7 @@ export const gridColumns2: Array<GridColumn> = [
         headerText: 'Is Updated',
         width: 100,
         dataType: DataTypeEnum.Boolean,
-        boolFormatType: BoolFormatTypeEnum.Both
+        boolFormatType: BoolFormatTypeEnum.CheckmarkAndCross
     }
 ];
 

--- a/src/components/QuickGrid/CellFormatters.tsx
+++ b/src/components/QuickGrid/CellFormatters.tsx
@@ -1,0 +1,27 @@
+import { BoolFormatTypeEnum } from './QuickGrid.Props';
+import { Icon } from '../Icon/Icon';
+import React = require('react');
+
+export function boolFormatterFactory(type: BoolFormatTypeEnum): (cellData: any, rowData: any) => any {
+    switch (type) {
+        case BoolFormatTypeEnum.CheckmarkOnly:
+            return (cellData: any, rowData: any) => {
+                return <div className="grid-component-cell-inner" >
+                    <Icon className="center-icon" iconName={ cellData ? 'svg-icon-checkmark' : null}/>
+                </div>;
+            };
+        case BoolFormatTypeEnum.CheckmarkAndCross:
+            return (cellData: any, rowData: any) => {
+                return <div className="grid-component-cell-inner" >
+                    <Icon className="center-icon" iconName={ cellData ? 'svg-icon-checkmark' : 'svg-icon-delete'}/>
+                </div>;
+            };
+        case BoolFormatTypeEnum.TextOnly:
+        default:
+            return (cellData: any, rowData: any) => {
+                return <div className="grid-component-cell-inner" >
+                    {cellData ? 'True' : 'False'}
+                </div>;
+            };
+    }
+}

--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -4,7 +4,6 @@ import { ITooltipProps } from '../Tooltip/Tooltip.props';
 export interface IQuickGrid {
     scrollToRow(index: number): void;
     updateColumnWidth(columnIndex: number, getWidth: (oldWidth: number) => number): void;
-    formatBoolCell(column: GridColumn, cellData: any): any;
 }
 
 export enum SortDirection {

--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -99,7 +99,7 @@ export enum BoolFormatTypeEnum {
     /**
      * Checkmark for true, cross for false
      */
-    Both
+    CheckmarkAndCross
 }
 
 export interface GridColumn {

--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -4,6 +4,7 @@ import { ITooltipProps } from '../Tooltip/Tooltip.props';
 export interface IQuickGrid {
     scrollToRow(index: number): void;
     updateColumnWidth(columnIndex: number, getWidth: (oldWidth: number) => number): void;
+    formatBoolCell(column: GridColumn, cellData: any): any;
 }
 
 export enum SortDirection {
@@ -82,13 +83,30 @@ export interface GroupRow {
 export enum DataTypeEnum {
     Number,
     String,
-    Date
+    Date,
+    Boolean
+}
+
+export enum BoolFormatTypeEnum {
+    /**
+     * No icons, only text
+     */
+    TextOnly,
+    /**
+     * Checkmark for true, nothing for false
+     */
+    CheckmarkOnly,
+    /**
+     * Checkmark for true, cross for false
+     */
+    Both
 }
 
 export interface GridColumn {
     headerText: string;
     valueMember: string; // for sort & grouping
     dataType?: DataTypeEnum;
+    boolFormatType?: BoolFormatTypeEnum;
     isSortable?: boolean; // default true
     isGroupable?: boolean; // default true
     sortByValueGetter?: (cellData, sortDirection: SortDirection) => any;
@@ -145,4 +163,3 @@ export interface ActionItem {
     parameters?: any;
     tooltip?: ITooltipProps;
 }
-

--- a/src/components/QuickGrid/QuickGrid.scss
+++ b/src/components/QuickGrid/QuickGrid.scss
@@ -172,6 +172,11 @@
             &.is-selected {
                 background-color: $selected-item-background;
             }
+            
+            .center-icon {
+                display: block;
+                margin: auto;
+            }
 
             .status-critical {
                 color: $error-status-server;

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -19,7 +19,9 @@ import {
     IQuickGridProps,
     IQuickGridState,
     QuickGridActionsBehaviourEnum,
-    SortDirection
+    SortDirection,
+    DataTypeEnum,
+    BoolFormatTypeEnum
 } from './QuickGrid.Props';
 import { GridFooter } from './QuickGridFooter';
 import { GridHeader } from './QuickGridHeader';
@@ -474,6 +476,8 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         const columnElement = () => {
             if (column.cellFormatter) {
                 return column.cellFormatter(cellData, rowData);
+            } else if (column.dataType === DataTypeEnum.Boolean) {
+                return this.formatBoolCell(column, cellData);
             } else {
                 return (
                     <div className="grid-component-cell-inner" >
@@ -499,6 +503,29 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                 {isLastColumn && this.renderRowContextActions(rowIndex, rowData, isSelectedRow)}
             </div>
         );
+    }
+
+    formatBoolCell(column: GridColumn, cellData: any) {
+        let element;
+        switch (column.boolFormatType) {
+            case BoolFormatTypeEnum.CheckmarkOnly:
+                element = <div className="grid-component-cell-inner" >
+                    <Icon className="center-icon" iconName={ cellData ? 'svg-icon-checkmark' : null}/>
+                </div>;
+                break;
+            case BoolFormatTypeEnum.Both:
+                element = <div className="grid-component-cell-inner" >
+                    <Icon className="center-icon" iconName={ cellData ? 'svg-icon-checkmark' : 'svg-icon-delete'}/>
+                </div>;
+                break;
+            case BoolFormatTypeEnum.TextOnly:
+            default:
+                element = <div className="grid-component-cell-inner" >
+                    {cellData ? 'True' : 'False'}
+                </div>;
+
+        }
+        return element;
     }
 
     renderRowContextActions = (rowIndex, rowData, isSelectedRow) => {

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -513,7 +513,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                     <Icon className="center-icon" iconName={ cellData ? 'svg-icon-checkmark' : null}/>
                 </div>;
                 break;
-            case BoolFormatTypeEnum.Both:
+            case BoolFormatTypeEnum.CheckmarkAndCross:
                 element = <div className="grid-component-cell-inner" >
                     <Icon className="center-icon" iconName={ cellData ? 'svg-icon-checkmark' : 'svg-icon-delete'}/>
                 </div>;

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -157,6 +157,11 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
     getColumnsToDisplay(columns: Array<GridColumn>, groupBy: Array<IGroupBy>, hasActionColumn: boolean) {
         const groupByColumnNames = groupBy.map(col => col.column);
         let displayColumns = columns.filter((column) => { return groupByColumnNames.indexOf(column.valueMember) === -1; });
+        displayColumns.map((column) => {
+            if (column.cellFormatter == null && column.dataType === DataTypeEnum.Boolean) {
+                column.cellFormatter = this.formatBoolCell;
+            }
+        });
         let emptyArray = new Array();
         if (hasActionColumn) {
             emptyArray.push({
@@ -476,8 +481,6 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         const columnElement = () => {
             if (column.cellFormatter) {
                 return column.cellFormatter(cellData, rowData);
-            } else if (column.dataType === DataTypeEnum.Boolean) {
-                return this.formatBoolCell(column, cellData);
             } else {
                 return (
                     <div className="grid-component-cell-inner" >
@@ -505,9 +508,10 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         );
     }
 
-    formatBoolCell(column: GridColumn, cellData: any) {
+    formatBoolCell(cellData: any, rowData: any) {
+        const _ref: any = this;
         let element;
-        switch (column.boolFormatType) {
+        switch (_ref.boolFormatType) {
             case BoolFormatTypeEnum.CheckmarkOnly:
                 element = <div className="grid-component-cell-inner" >
                     <Icon className="center-icon" iconName={ cellData ? 'svg-icon-checkmark' : null}/>

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -27,6 +27,7 @@ import { GridFooter } from './QuickGridFooter';
 import { GridHeader } from './QuickGridHeader';
 import { QuickGridRowContextActionsHandler } from './QuickGridRowContextActionsHandler';
 import { IQuickGrid } from '.';
+import { boolFormatterFactory } from './CellFormatters';
 
 const scrollbarSize = require('dom-helpers/util/scrollbarSize');
 
@@ -159,7 +160,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         let displayColumns = columns.filter((column) => { return groupByColumnNames.indexOf(column.valueMember) === -1; });
         displayColumns.map((column) => {
             if (column.cellFormatter == null && column.dataType === DataTypeEnum.Boolean) {
-                column.cellFormatter = this.formatBoolCell;
+                column.cellFormatter = boolFormatterFactory(column.boolFormatType);
             }
         });
         let emptyArray = new Array();
@@ -506,30 +507,6 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                 {isLastColumn && this.renderRowContextActions(rowIndex, rowData, isSelectedRow)}
             </div>
         );
-    }
-
-    formatBoolCell(cellData: any, rowData: any) {
-        const _ref: any = this;
-        let element;
-        switch (_ref.boolFormatType) {
-            case BoolFormatTypeEnum.CheckmarkOnly:
-                element = <div className="grid-component-cell-inner" >
-                    <Icon className="center-icon" iconName={ cellData ? 'svg-icon-checkmark' : null}/>
-                </div>;
-                break;
-            case BoolFormatTypeEnum.CheckmarkAndCross:
-                element = <div className="grid-component-cell-inner" >
-                    <Icon className="center-icon" iconName={ cellData ? 'svg-icon-checkmark' : 'svg-icon-delete'}/>
-                </div>;
-                break;
-            case BoolFormatTypeEnum.TextOnly:
-            default:
-                element = <div className="grid-component-cell-inner" >
-                    {cellData ? 'True' : 'False'}
-                </div>;
-
-        }
-        return element;
     }
 
     renderRowContextActions = (rowIndex, rowData, isSelectedRow) => {

--- a/src/components/TreeCompare/TreeCompare.tsx
+++ b/src/components/TreeCompare/TreeCompare.tsx
@@ -42,7 +42,7 @@ export class TreeCompare extends React.PureComponent<ITreeCompareProps, ITreeCom
                 <TreeGrid
                     columns={this.state.compareColumns}
                     treeDataSource={this.state.dataSource}
-                    isNodeSelectable={false}
+                    isNodeSelectable={true}
                 />
             </div>
         );

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { IFinalTreeNode } from '../../models/TreeData';
 import { getTreeRowsSelector } from './TreeGridDataSelectors';
 import { Icon } from '../Icon/Icon';
-import { getColumnMinWidth, GridColumn, ICustomCellRendererArgs, IQuickGrid, QuickGrid, DataTypeEnum } from '../QuickGrid';
+import { getColumnMinWidth, GridColumn, ICustomCellRendererArgs, IQuickGrid, QuickGrid, DataTypeEnum, BoolFormatTypeEnum } from '../QuickGrid';
 import { Spinner } from '../Spinner/Spinner';
 import { SpinnerType } from '../Spinner/Spinner.Props';
 import { CellElement } from './CellElement';
@@ -77,6 +77,9 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         };
         expandedColumns.push(replacementFirstColumn);
         for (let i = 1; i < columns.length; i++) {
+            if (columns[i].cellFormatter == null && columns[i].dataType === DataTypeEnum.Boolean) {
+                columns[i].cellFormatter = this.formatBoolCell;
+            }
             expandedColumns.push(columns[i]);
         }
         return expandedColumns;
@@ -229,8 +232,6 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
 
         } else if (column.cellFormatter) {
             columnElement = column.cellFormatter(cellData, rowData);
-        } else if (column.dataType === DataTypeEnum.Boolean) {
-            columnElement = this._quickGrid.formatBoolCell(column, cellData);
         } else {
             columnElement = [
                 columnIndex === 1 && rowData.iconName ? <span key="cellIcon" style={{ display: 'flex' }} title={rowData.iconTooltipContent}><Icon iconName={rowData.iconName} className={rowData.iconClassName} /></span> : null,
@@ -263,6 +264,29 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         );
     }
 
+    private formatBoolCell(cellData: any, rowData: any) {
+        const _ref: any = this;
+        let element;
+        switch (_ref.boolFormatType) {
+            case BoolFormatTypeEnum.CheckmarkOnly:
+                element = <div className="grid-component-cell-inner" >
+                    <Icon className="center-icon" iconName={ cellData ? 'svg-icon-checkmark' : null}/>
+                </div>;
+                break;
+            case BoolFormatTypeEnum.CheckmarkAndCross:
+                element = <div className="grid-component-cell-inner" >
+                    <Icon className="center-icon" iconName={ cellData ? 'svg-icon-checkmark' : 'svg-icon-delete'}/>
+                </div>;
+                break;
+            case BoolFormatTypeEnum.TextOnly:
+            default:
+                element = <div className="grid-component-cell-inner" >
+                    {cellData ? 'True' : 'False'}
+                </div>;
+
+        }
+        return element;
+    }
 
     private _onTreeExpandToggleClick = (ev, rowData: IFinalTreeNode) => {
         // with this call we are telling underlying grid not to scroll on selected position on render update

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -77,10 +77,11 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         };
         expandedColumns.push(replacementFirstColumn);
         for (let i = 1; i < columns.length; i++) {
-            if (columns[i].cellFormatter == null && columns[i].dataType === DataTypeEnum.Boolean) {
-                columns[i].cellFormatter = this.formatBoolCell;
+            let col: GridColumn = { ...columns[i] };
+            if (col.cellFormatter == null && col.dataType === DataTypeEnum.Boolean) {
+                col.cellFormatter = this.formatBoolCell;
             }
-            expandedColumns.push(columns[i]);
+            expandedColumns.push(col);
         }
         return expandedColumns;
     }

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -9,6 +9,7 @@ import { Spinner } from '../Spinner/Spinner';
 import { SpinnerType } from '../Spinner/Spinner.Props';
 import { CellElement } from './CellElement';
 import { ITreeGridProps, ITreeGridState } from './TreeGrid.Props';
+import { boolFormatterFactory } from '../QuickGrid/CellFormatters';
 
 export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState> {
     public static defaultProps = {
@@ -79,7 +80,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         for (let i = 1; i < columns.length; i++) {
             let col: GridColumn = { ...columns[i] };
             if (col.cellFormatter == null && col.dataType === DataTypeEnum.Boolean) {
-                col.cellFormatter = this.formatBoolCell;
+                col.cellFormatter = boolFormatterFactory(col.boolFormatType);
             }
             expandedColumns.push(col);
         }

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { IFinalTreeNode } from '../../models/TreeData';
 import { getTreeRowsSelector } from './TreeGridDataSelectors';
 import { Icon } from '../Icon/Icon';
-import { getColumnMinWidth, GridColumn, ICustomCellRendererArgs, IQuickGrid, QuickGrid } from '../QuickGrid';
+import { getColumnMinWidth, GridColumn, ICustomCellRendererArgs, IQuickGrid, QuickGrid, DataTypeEnum, QuickGridInner } from '../QuickGrid';
 import { Spinner } from '../Spinner/Spinner';
 import { SpinnerType } from '../Spinner/Spinner.Props';
 import { CellElement } from './CellElement';
@@ -226,8 +226,11 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
                     Loading...
                     </span>
             </div>;
+
         } else if (column.cellFormatter) {
             columnElement = column.cellFormatter(cellData, rowData);
+        } else if (column.dataType === DataTypeEnum.Boolean) {
+            columnElement = this._quickGrid.formatBoolCell(column, cellData);
         } else {
             columnElement = [
                 columnIndex === 1 && rowData.iconName ? <span key="cellIcon" style={{ display: 'flex' }} title={rowData.iconTooltipContent}><Icon iconName={rowData.iconName} className={rowData.iconClassName} /></span> : null,

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { IFinalTreeNode } from '../../models/TreeData';
 import { getTreeRowsSelector } from './TreeGridDataSelectors';
 import { Icon } from '../Icon/Icon';
-import { getColumnMinWidth, GridColumn, ICustomCellRendererArgs, IQuickGrid, QuickGrid, DataTypeEnum, QuickGridInner } from '../QuickGrid';
+import { getColumnMinWidth, GridColumn, ICustomCellRendererArgs, IQuickGrid, QuickGrid, DataTypeEnum } from '../QuickGrid';
 import { Spinner } from '../Spinner/Spinner';
 import { SpinnerType } from '../Spinner/Spinner.Props';
 import { CellElement } from './CellElement';


### PR DESCRIPTION
Added support for boolean DataType column in both QuickGrid and TreeGrid components. Default display is textual. 
To render with icons pick an appropriate BoolFormatType for the optional gridColumn of the same naming.