### PR TITLE
nodesById to public

### DIFF
--- a/src/models/TreeData.ts
+++ b/src/models/TreeData.ts
@@ -22,7 +22,7 @@ export interface IFinalTreeNode extends TreeNode {
     descendantSatisfiesFilterCondition?: boolean;
 }
 
-interface ILookupTable {
+export interface ILookupTable {
     [id: number]: IFinalTreeNode;
 }
 
@@ -38,7 +38,7 @@ interface ILookupTable {
  * ie. we add a new child to the tree, react will register the change and the TreeGrid component will update because of the prop change
  */
 export class TreeDataSource {
-    private nodesById: ILookupTable;
+    public nodesById: ILookupTable;
     private idCounter: number = 0;
     // this would constitute a really dirty hack
     // React shallow compares each prop that is an object before even calling ShouldComponentUpdate    


### PR DESCRIPTION
nodesById changed to from private to public. I need this functionality for my filter. Perhaps it can be avoided, but many of the current logic inside the filter relies on it. Hope it doesn't cause any problems somewhere else.