### PR TITLE
Feat/tree grid select row

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "quick-react-ts",
-    "version": "0.10.50",
+    "version": "0.10.51",
     "description": "Reusable components for React, written in TypeScript",
     "main": "./lib/index.js",
     "typings": "./lib/index",

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -300,7 +300,9 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                 }
             }
 
-            this.setSelectedRowIndex(rowIndex, rowData);
+            if (this.props.isRowSelectable) {
+                this.setSelectedRowIndex(rowIndex, rowData);
+            }
         };
 
 
@@ -337,7 +339,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
     renderEmptyCell(key, rowIndex, rowData, style) {
         const rowClass = 'grid-row-' + rowIndex;
         const onMouseEnter = () => { this.onMouseEnterCell(rowIndex); };
-        const onClick = () => { this.setSelectedRowIndex(rowIndex, rowData); };
+        const onClick = this.props.isRowSelectable ? () => { this.setSelectedRowIndex(rowIndex, rowData); } : null;
 
         const onDoubleClick = () => {
             if (this.props.onRowDoubleClicked) {


### PR DESCRIPTION
Before call for method this.setSelectedRowIndex, I added check if row is selectable because sometimes I can select row even when I don't want that.