### PR TITLE
added getObjectValue helper method

### DIFF
--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -28,6 +28,7 @@ import { GridHeader } from './QuickGridHeader';
 import { QuickGridRowContextActionsHandler } from './QuickGridRowContextActionsHandler';
 import { IQuickGrid } from '.';
 import { boolFormatterFactory } from './CellFormatters';
+import { getObjectValue } from '../../utilities/getObjectValue';
 
 const scrollbarSize = require('dom-helpers/util/scrollbarSize');
 
@@ -463,7 +464,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         const isLastColumn = !notLastIndex;
         const column = columns[columnIndex];
         const dataKey = column.dataMember || column.valueMember;
-        const cellData = rowData[dataKey];
+        const cellData = getObjectValue(rowData, dataKey);
         const rowClass = 'grid-row-' + rowIndex;
         const isSelectedRow = rowIndex === this.state.selectedRowIndex;
         const className = classNames(

--- a/src/components/QuickGrid/QuickGridFooter.tsx
+++ b/src/components/QuickGrid/QuickGridFooter.tsx
@@ -4,6 +4,7 @@ import { GridColumn, SortDirection, IGroupBy } from './QuickGrid.Props';
 import { shallowCompareArrayEqual } from '../../utilities/array';
 import { Grid } from 'react-virtualized';
 import './QuickGrid.scss';
+import { getObjectValue } from '../../utilities/getObjectValue';
 
 export interface IGridFooterProps {
     columnWidths: Array<number>;
@@ -43,7 +44,7 @@ export class GridFooter extends React.PureComponent<IGridFooterProps, IGridFoote
         const columns = this.props.columns;
         const column = columns[columnIndex];
         const dataKey = column.dataMember || column.valueMember;
-        const cellData = this.props.rowData[dataKey];
+        const cellData = getObjectValue(this.props.rowData, dataKey);
         const title = this.props.tooltipsEnabled ? cellData : null;
         
         const className = classNames(

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -10,6 +10,7 @@ import { SpinnerType } from '../Spinner/Spinner.Props';
 import { CellElement } from './CellElement';
 import { ITreeGridProps, ITreeGridState } from './TreeGrid.Props';
 import { boolFormatterFactory } from '../QuickGrid/CellFormatters';
+import { getObjectValue } from '../../utilities/getObjectValue';
 
 export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState> {
     public static defaultProps = {
@@ -197,7 +198,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         const notLastIndex = columnIndex < (columns.length - 1);
         const column = columns[columnIndex];
         const dataKey = column.dataMember || column.valueMember;
-        const cellData = rowData[dataKey];
+        const cellData = getObjectValue(rowData, dataKey);
         const rowClass = 'grid-row-' + rowIndex;
         const className = classNames(
             'grid-component-cell',
@@ -264,30 +265,6 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
                 element={columnElement}
             />
         );
-    }
-
-    private formatBoolCell(cellData: any, rowData: any) {
-        const _ref: any = this;
-        let element;
-        switch (_ref.boolFormatType) {
-            case BoolFormatTypeEnum.CheckmarkOnly:
-                element = <div className="grid-component-cell-inner" >
-                    <Icon className="center-icon" iconName={ cellData ? 'svg-icon-checkmark' : null}/>
-                </div>;
-                break;
-            case BoolFormatTypeEnum.CheckmarkAndCross:
-                element = <div className="grid-component-cell-inner" >
-                    <Icon className="center-icon" iconName={ cellData ? 'svg-icon-checkmark' : 'svg-icon-delete'}/>
-                </div>;
-                break;
-            case BoolFormatTypeEnum.TextOnly:
-            default:
-                element = <div className="grid-component-cell-inner" >
-                    {cellData ? 'True' : 'False'}
-                </div>;
-
-        }
-        return element;
     }
 
     private _onTreeExpandToggleClick = (ev, rowData: IFinalTreeNode) => {

--- a/src/utilities/getObjectValue.ts
+++ b/src/utilities/getObjectValue.ts
@@ -1,0 +1,19 @@
+ /**
+ * Get value for object from path.
+ * @param {string} path - Property name of object. For nested objects use property.nested
+ */
+export function getObjectValue(theObject: any, path: string, separator = '.') {
+    try {
+        return path.
+                replace('[', separator).replace(']', '').
+                split(separator).
+                reduce(
+                    (obj, property) => {
+                        return obj[property];
+                    }, theObject
+                );
+
+    } catch (err) {
+        return undefined;
+    }
+}


### PR DESCRIPTION
TreeGrid and QuickGrid components now support getting cell values from nested objects.

For this scenario the proper format type of ValueMember or DataMember is `object.property`