### PR TITLE
changed icons for bool columns

### DIFF
--- a/examples/MockData/gridData.ts
+++ b/examples/MockData/gridData.ts
@@ -132,7 +132,7 @@ export const gridColumns1: Array<GridColumn> = [
         headerText: 'Is Updated',
         width: 100,
         dataType: DataTypeEnum.Boolean,
-        boolFormatType: BoolFormatTypeEnum.CheckmarkAndCross
+        boolFormatType: BoolFormatTypeEnum.TextOnly
     }
 ];
 
@@ -169,7 +169,7 @@ export const gridColumns2: Array<GridColumn> = [
         headerText: 'Is Updated',
         width: 100,
         dataType: DataTypeEnum.Boolean,
-        boolFormatType: BoolFormatTypeEnum.CheckmarkAndCross
+        boolFormatType: BoolFormatTypeEnum.TextOnly
     }
 ];
 

--- a/src/components/QuickGrid/CellFormatters.tsx
+++ b/src/components/QuickGrid/CellFormatters.tsx
@@ -7,13 +7,13 @@ export function boolFormatterFactory(type: BoolFormatTypeEnum): (cellData: any, 
         case BoolFormatTypeEnum.CheckmarkOnly:
             return (cellData: any, rowData: any) => {
                 return <div className="grid-component-cell-inner" >
-                    <Icon className="center-icon" iconName={ cellData ? 'svg-icon-checkmark' : null}/>
+                    <Icon className="center-icon" iconName={ cellData ? 'svg-icon-check' : null}/>
                 </div>;
             };
         case BoolFormatTypeEnum.CheckmarkAndCross:
             return (cellData: any, rowData: any) => {
                 return <div className="grid-component-cell-inner" >
-                    <Icon className="center-icon" iconName={ cellData ? 'svg-icon-checkmark' : 'svg-icon-delete'}/>
+                    <Icon className="center-icon" iconName={ cellData ? 'svg-icon-check' : 'svg-icon-close'}/>
                 </div>;
             };
         case BoolFormatTypeEnum.TextOnly:


### PR DESCRIPTION
Ideally I should have created a BoolOptions prop for GridColumn where you could specify both type and icons. But that would require more refactor in our other app, and since we already have this kind of "invisible icons" in some places I decided to go the easy way.