### PR TITLE
Close tooltip on click

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -60,6 +60,7 @@ export class Tooltip extends CommonComponent<ITooltipProps, any> {
                 { ...{ onBlurCapture: this._onTooltipMouseLeave } }
                 onMouseEnter={this._onTooltipMouseEnter}
                 onMouseLeave={this._onTooltipMouseLeave}
+                onMouseUpCapture={this._onTooltipMouseLeave}
                 className={tooltipContainerClass}>
 
                 {children}


### PR DESCRIPTION
Tooltip sometimes stays open when click triggers some kind of an action. This will ensure tooltip will always close