### PR TITLE
Scroll to index for virtualized treeview fix

### DIFF
--- a/src/components/TreeFilter/VirtualizedTreeView.Props.ts
+++ b/src/components/TreeFilter/VirtualizedTreeView.Props.ts
@@ -49,4 +49,5 @@ export interface IVirtualizedTreeViewState {
     filteredItems: Array<TreeItem>;
     searchText: string;
     partiallyCheckedItemIds: Array<string>;
+    scrollToIndex: number;
 }


### PR DESCRIPTION
Before, checking items in a large treeFilter would scroll to the beginning or to the first selected item on each render. This would happen even when merely expanding nodes if there was any selection beforehand.

I moved the logic to componentWillMount phase so the scroll happens only upon mounting, and have also updated it to work with nested ids.