### PR TITLE
Bug/tree min width

### DIFF
--- a/examples/MockData/gridData.ts
+++ b/examples/MockData/gridData.ts
@@ -104,7 +104,6 @@ export const gridColumns1: Array<GridColumn> = [
         valueMember: 'Name',
         headerText: 'Name',
         width: 100,
-        minWidth: 100,
         headerTooltip: 'This is names column.'
     }, 
     {

--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -127,11 +127,7 @@ export function getColumnMinWidth(col: GridColumn): number {
     } else {
         retVal = col.minWidth;
     }
-    if (retVal) {
-        return retVal;
-    }
-
-    return defaultMinColumnWidth;
+    return retVal || defaultMinColumnWidth;
 }
 
 export const lowercasedColumnPrefix = 'lowercase_';

--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -119,11 +119,19 @@ export interface GridColumn {
     headerTooltip?: string;
 }
 
+export const defaultMinColumnWidth = 50;
 export function getColumnMinWidth(col: GridColumn): number {
+    let retVal: number;
     if (col.minWidth instanceof Function) {
-        return col.minWidth();
+        retVal = col.minWidth();
+    } else {
+        retVal = col.minWidth;
     }
-    return col.minWidth;
+    if (retVal) {
+        return retVal;
+    }
+
+    return defaultMinColumnWidth;
 }
 
 export const lowercasedColumnPrefix = 'lowercase_';

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -32,7 +32,6 @@ import { getObjectValue } from '../../utilities/getObjectValue';
 
 const scrollbarSize = require('dom-helpers/util/scrollbarSize');
 
-const defaultMinColumnWidth = 50;
 const emptyCellWidth = 5;
 
 export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridState> implements IQuickGrid {
@@ -70,7 +69,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
             scrolledRow: undefined
         };
 
-        this._columnsMinTotalWidth = columnsToDisplay.map(x => getColumnMinWidth(x) || defaultMinColumnWidth).reduce((a, b) => a + b, 0);
+        this._columnsMinTotalWidth = columnsToDisplay.map(getColumnMinWidth).reduce((a, b) => a + b, 0);
         this.onGridResize = _.debounce(this.onGridResize, 100);
         this._finalGridRows = props.hasCustomRowSelector ? props.rows : getRowsSelector(this.state, props);
     }
@@ -193,7 +192,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
             const columnsToDisplay = nextProps.hasStaticColumns ? nextProps.columns : this.getColumnsToDisplay(nextProps.columns, newGroupBy, hasActionColumn);
             const columnWidths = this.getColumnWidths(columnsToDisplay);
             this.setState((prevState) => { return { ...prevState, columnsToDisplay: columnsToDisplay, columnWidths: columnWidths, groupBy: newGroupBy }; });
-            this._columnsMinTotalWidth = columnsToDisplay.map(x => getColumnMinWidth(x) || defaultMinColumnWidth).reduce((a, b) => a + b, 0);
+            this._columnsMinTotalWidth = columnsToDisplay.map(getColumnMinWidth).reduce((a, b) => a + b, 0);
         }
     }
 
@@ -561,7 +560,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
             const totalWidth = columnsToDisplay.map(x => x.width).reduce((a, b) => a + b, 0) - fixedColumnsTotalWidth;
             newColumnWidths = columnsToDisplay.map((col) => this.getColumnWidthInPx(available, totalWidth, col.width, col.fixedWidth));
         } else {
-            newColumnWidths = columnsToDisplay.map(x => getColumnMinWidth(x) || defaultMinColumnWidth);
+            newColumnWidths = columnsToDisplay.map(getColumnMinWidth);
         }
 
         const totalNewWidth = newColumnWidths.reduce((a, b) => a + b, 0);
@@ -569,7 +568,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         if (empty > 0) {
             newColumnWidths[newColumnWidths.length - 1] = newColumnWidths[newColumnWidths.length - 1] + empty;
         }
-
+        
         return newColumnWidths;
     }
 


### PR DESCRIPTION
Not much to say, when called from the quickGridHeader at some point the widhts array contained a NaN value. i decided that it was better to put the logic in the getColumnMinWidth function.