### PR TITLE
Refactor/tree grid branches/tree data source

### DIFF
--- a/examples/src/TreeGrid.tsx
+++ b/examples/src/TreeGrid.tsx
@@ -66,7 +66,7 @@ export class Index extends React.Component<any, any> {
 
     onSelectedNodeChanged = (selectedNode: IFinalTreeNode) => {
         this.setState({
-            selectedNode: selectedNode.nodeId
+            selectedNode: selectedNode.$meta.nodeId
         });
     }
 
@@ -119,7 +119,7 @@ export class Index extends React.Component<any, any> {
                 newChildNode.isExpanded = false;
                 children.push(newChildNode);
             }
-            let newData = this.state.data.updateNode(node.nodeId, { children });
+            let newData = this.state.data.updateNode(node.$meta.nodeId, { children });
             this.setState(prev => ({ data: newData }));
         }, 2000);
     }

--- a/src/components/TreeGrid/TreeGrid.Props.ts
+++ b/src/components/TreeGrid/TreeGrid.Props.ts
@@ -24,5 +24,5 @@ export interface ITreeGridState {
     sortDirection?: SortDirection;
     sortRequestId: number;
     structureRequestChangeId: number;
-    selectedNodeId?: number;
+    selectedNodeId?: number | string;
 }

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -49,7 +49,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
     }
 
     componentDidMount() {
-        const rowIndex = this._finalGridRows.findIndex(e => e.nodeId === this.state.selectedNodeId);
+        const rowIndex = this._finalGridRows.findIndex(e => e.$meta.nodeId === this.state.selectedNodeId);
         this._quickGrid.scrollToRow(rowIndex);
     }
 
@@ -109,11 +109,10 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
     treeCellRenderer = (args: ICustomCellRendererArgs) => {
         let { columnIndex, key, rowIndex, style, onMouseEnter, rowActionsRender, onMouseClick } = args;
         const rowData = this._finalGridRows[rowIndex];
-        const rowID: number = rowData.nodeId;
-        let isSelectedRow = this.state.selectedNodeId && this.state.selectedNodeId === rowData.nodeId;
+        let isSelectedRow = this.state.selectedNodeId && this.state.selectedNodeId === rowData.$meta.nodeId;
         const indentSize = 20;
         let indent = 0;
-        let level = rowData.nodeLevel;
+        let level = rowData.$meta.nodeLevel;
         if ((columnIndex === 0 || columnIndex === 1)) {
 
             indent = level * indentSize;
@@ -156,7 +155,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
     }
 
     private _renderExpandCollapseButton(key, rowIndex: number, rowData: IFinalTreeNode, style, onMouseEnter, isSelectedRow: boolean) {
-        const showNodeAsExpanded = rowData.isExpanded || rowData.descendantSatisfiesFilterCondition;
+        const showNodeAsExpanded = rowData.isExpanded || rowData.$meta.descendantSatisfiesFilterCondition;
         let actionsTooltip = showNodeAsExpanded ? 'Collapse' : 'Expand';
         let iconName = showNodeAsExpanded ? 'svg-icon-arrowCollapse' : 'svg-icon-arrowExpand';
         let icon = null;
@@ -276,8 +275,8 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
             && (!rowData.children || rowData.children.length === 0)
             && rowData.hasChildren
             && this.props.onLazyLoadChildNodes
-            && !rowData.isLazyChildrenLoadInProgress) {
-            rowData.isLazyChildrenLoadInProgress = true;
+            && !rowData.$meta.isLazyChildrenLoadInProgress) {
+            rowData.$meta.isLazyChildrenLoadInProgress = true;
             this.props.onLazyLoadChildNodes(rowData);
         }
         this.setState((oldState) => {
@@ -293,26 +292,26 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
     }
 
     private _setSelectedNode = (rowIndex: number, nodeData: IFinalTreeNode) => {
-        if (this.state.selectedNodeId === nodeData.nodeId) {
+        if (this.state.selectedNodeId === nodeData.$meta.nodeId) {
             return;
         }
-        this.setState({ selectedNodeId: nodeData.nodeId });
+        this.setState({ selectedNodeId: nodeData.$meta.nodeId });
         if (this.props.onSelectedNodeChanged) {
             this.props.onSelectedNodeChanged(this._finalGridRows[rowIndex]);
         }
     }
 
-    private _setSelectedNodeAndState = (nodeId: number) => {
+    private _setSelectedNodeAndState = (nodeId: number | string) => {
         if (this.state.selectedNodeId === nodeId) {
             return;
         }
         this.setState({ selectedNodeId: nodeId });
 
         if (this.props.onSelectedNodeChanged) {
-            const selectedNode = this._finalGridRows.find((element) => { return element.nodeId === nodeId; });
+            const selectedNode = this._finalGridRows.find((element) => { return element.$meta.nodeId === nodeId; });
             this.props.onSelectedNodeChanged(selectedNode);
         }
-        const selectedRowIndex = this._finalGridRows.findIndex((element) => element.nodeId === nodeId);
+        const selectedRowIndex = this._finalGridRows.findIndex((element) => element.$meta.nodeId === nodeId);
 
         this._quickGrid.scrollToRow(selectedRowIndex);
     }

--- a/src/models/TreeData.ts
+++ b/src/models/TreeData.ts
@@ -53,7 +53,9 @@ export class TreeDataSource {
     public isEmpty: boolean;
     /**
      * 
-     * @param root warning: will be mutated and returned as ITreeDataSource
+     * @param input warning: will be mutated and returned as ITreeDataSource
+     * @param idMember the field that contains the id of the node, or a function that returns a unique id for a node.
+     * If no parameter is supplied ids will be generated automatically
      */
     constructor(input: TreeNode | TreeDataSource | Array<any>, idMember?: string | ((node: any) => string | number)) {
         if (this.isDataSource(input)) {


### PR DESCRIPTION
This PR is  to show the direction i want to take the TreeGrid. Some additional changes are yet to be made if possible.


Almost all of the calculated properties are now inside $meta when working with a TreeNode. 
I left the parentNode in the treenode because it just feels natural to type node.parent and you expect such a propety to exist.

Talking with @mpisacic we came to the conclusion that while the surogate key functionality is great for working with any data without worrying about id and parentId,  handling of some kind of original identifier is required. 
So i added an additional parameter to the TreeDataSource constructor where you can define if you choose so what is the true identifier of the node, either with a function or by specifying which member it is.

**Edit:**: i do not actually plan to merge this to master yet.
