### PR TITLE
Feat/tree multiselect

### DIFF
--- a/examples/MockData/gridData.ts
+++ b/examples/MockData/gridData.ts
@@ -23,7 +23,7 @@ export interface GridData extends TreeNode {
 
 let totalItems = 0;
 
-const randomLower = (str : string) => Math.random() > 0.5 ? str : str.toLowerCase();
+const randomLower = (str: string) => Math.random() > 0.5 ? str : str.toLowerCase();
 
 export const nodeActions = [
     {
@@ -49,14 +49,14 @@ export const nodeActions = [
 ];
 
 export const generateTreeNode = () => {
-    totalItems++;  
-    return {                        
-        isExpanded: true,            
+    totalItems++;
+    return {
+        isExpanded: true,
         children: [],
         iconName: 'svg-icon-world',
-        hasChildren: true,       
+        hasChildren: true,
         Name: RANDOM_Names[Math.floor(Math.random() * RANDOM_Names.length)],
-        Color:  randomLower(RANDOM_Color[Math.floor(Math.random() * RANDOM_Color.length)]),
+        Color: randomLower(RANDOM_Color[Math.floor(Math.random() * RANDOM_Color.length)]),
         Animal: RANDOM_Animal[Math.floor(Math.random() * RANDOM_Animal.length)],
         Mixed: RANDOM_Mix[Math.floor(Math.random() * RANDOM_Mix.length)],
         Numbers: Math.floor(Math.random() * 30),
@@ -64,14 +64,14 @@ export const generateTreeNode = () => {
 
     };
 };
-const generateTreeData = (size: number): TreeNode => {
+export const generateTreeData = (size: number): TreeNode => {
     let treeSize: Array<number>;
     if (size === 0) {
         treeSize = [5, 5, 5, 2];
     } else {
-        treeSize = [10, 1000, 5, 10];
+        treeSize = [10, 100, 100];
     }
-    let result: Array<TreeNode> = [];   
+    let result: Array<TreeNode> = [];
 
 
 
@@ -83,10 +83,10 @@ const generateTreeData = (size: number): TreeNode => {
                 let treeEntry2 = generateTreeNode();
                 for (let l = 0; l < treeSize[3]; l++) {
                     let treeEntry3 = generateTreeNode();
-                     treeEntry3.isExpanded = false;
+                    treeEntry3.isExpanded = false;
                     treeEntry2.children.push(treeEntry3);
                 }
-                 treeEntry2.isExpanded = false;
+                treeEntry2.isExpanded = false;
                 treeEntry1.children.push(treeEntry2);
             }
             treeEntry.children.push(treeEntry1);
@@ -105,23 +105,23 @@ export const gridColumns1: Array<GridColumn> = [
         headerText: 'Name',
         width: 100,
         headerTooltip: 'This is names column.'
-    }, 
+    },
     {
         dataType: DataTypeEnum.String,
         valueMember: 'Color',
         headerText: 'Color',
         width: 100
-    }, 
+    },
     {
         valueMember: 'Animal',
         headerText: 'Animal - with very long header name',
         width: 100
-    }, 
+    },
     {
         valueMember: 'Mixed',
         headerText: 'Numbers and strings',
         width: 100
-    }, 
+    },
     {
         valueMember: 'Numbers',
         headerText: 'Numbers',
@@ -191,7 +191,7 @@ export function getGridData(numberOfElements) {
         data.push(
             {
                 RandomWords: RANDOM_WORDS[Math.floor(Math.random() * RANDOM_WORDS.length)],
-                Color:  RANDOM_Color[Math.floor(Math.random() * RANDOM_Color.length)],
+                Color: RANDOM_Color[Math.floor(Math.random() * RANDOM_Color.length)],
                 Animal: RANDOM_Animal[Math.floor(Math.random() * RANDOM_Animal.length)],
                 Mixed: RANDOM_Mix[Math.floor(Math.random() * RANDOM_Mix.length)],
                 Numbers: Math.floor(Math.random() * 30),
@@ -208,7 +208,7 @@ export function getSmallGridData(numberOfElements) {
         data.push(
             {
                 Animal: RANDOM_Animal[Math.floor(Math.random() * RANDOM_Animal.length)],
-                Color:  RANDOM_Color[Math.floor(Math.random() * RANDOM_Color.length)]
+                Color: RANDOM_Color[Math.floor(Math.random() * RANDOM_Color.length)]
             }
         );
     }

--- a/examples/src/Checkbox.tsx
+++ b/examples/src/Checkbox.tsx
@@ -6,6 +6,10 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 import { Checkbox } from './../../src/components/Checkbox/Checkbox';
+import { Icon } from '../../src/components/Icon/Icon';
+import { CellElement } from '../../src/components/TreeGrid/CellElement';
+import { VirtualizedTreeViewCheckBox } from '../../src/components/TreeFilter/VirtualizedTreeViewCheckBox';
+import { CheckStatus } from '../../src';
 
 const $secondaryColor = '#4D4D4F';
 
@@ -16,8 +20,20 @@ export class Index extends React.Component<any, any> {
         this.state = {
             checked: false,
             iconChecked: false,
-            checkedWhite: false
+            checkedWhite: false,
+            checkStatus: CheckStatus.ChildChecked
         };
+    }
+
+    onCheckBoxChange = () => {
+        let newChecked = CheckStatus.ChildChecked;
+        if (this.state.checkStatus === CheckStatus.NotChecked) {
+            this.setState({ checkStatus: CheckStatus.Checked });
+        } else if (this.state.checkStatus === CheckStatus.Checked) {
+            this.setState({ checkStatus: CheckStatus.NotChecked });
+        } else {
+            this.setState({ checkStatus: CheckStatus.NotChecked });
+        }
     }
 
     public render() {
@@ -28,6 +44,12 @@ export class Index extends React.Component<any, any> {
                     onChange={(ev, checked) => this._onChange()}
                     checked={this.state.checked}
                 />
+                <Checkbox
+                    onChange={(ev, checked) => this._onChange()}
+                    checked={this.state.checked}
+                />
+                <CellElement id={'1'} element={<Icon iconName="icon-arrow_down_right" className="expand-collapse-action-icon" />} />
+                <VirtualizedTreeViewCheckBox checked={this.state.checkStatus} itemId="1" text="" onChange={this.onCheckBoxChange} />
                 <Checkbox
                     label={'This is disabled checkbox'}
                     disabled={true}

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -24,6 +24,8 @@ $checkbox-transition-timing: cubic-bezier(.4, 0, .23, 1);
         cursor: pointer;
         margin-top: 5px;
         line-height: $checkbox-size;
+        min-width: $checkbox-size;
+        min-height: $checkbox-size;
         user-select: none;
         position: relative;
 
@@ -33,6 +35,7 @@ $checkbox-transition-timing: cubic-bezier(.4, 0, .23, 1);
             border-radius: 4px;
             width: $checkbox-size;
             height: $checkbox-size;
+            display: inline-block;
             position: absolute;
             box-sizing: border-box;
             transition-property: background, border, border-color;

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -15,10 +15,6 @@ export interface ICheckboxState {
 }
 
 export class Checkbox extends CommonComponent<ICheckboxProps, ICheckboxState> {
-
-    public static defaultProps: ICheckboxProps = {
-    };
-
     private id: string;
     private _checkBox: HTMLInputElement;
 
@@ -64,11 +60,11 @@ export class Checkbox extends CommonComponent<ICheckboxProps, ICheckboxState> {
             }
         );
         return (
-            <div className={className}>
+            <div className={className} style={this.props.style}>
                 <input
-                    { ...inputProps }
-                    { ...(checked !== undefined && { checked }) }
-                    { ...(defaultChecked !== undefined && { defaultChecked }) }
+                    {...inputProps}
+                    {...(checked !== undefined && { checked })}
+                    {...(defaultChecked !== undefined && { defaultChecked })}
                     disabled={disabled}
                     ref={this._resolveRef('_checkBox')}
                     className={'checkbox-input'}

--- a/src/components/LeftNavigation/LeftNavigation.tsx
+++ b/src/components/LeftNavigation/LeftNavigation.tsx
@@ -9,8 +9,7 @@ import { elementContains } from '../../utilities/elementContains';
 import { getWindow } from '../../utilities/getDocument';
 import { autobind } from '../../utilities/autobind';
 import './LeftNavigation.scss';
-
-const nullFunc = () => { };
+import { nullFunc } from '../../utilities/common';
 
 export class LeftNavigation extends CommonComponent<ILeftNavigationProps, any> {
     private _targetWindow: Window;
@@ -76,7 +75,7 @@ export class LeftNavigation extends CommonComponent<ILeftNavigationProps, any> {
         this.props.onClick(ev, item);
     }
 
-    private getSelectedId(options: Array<ILeftNavigationOption>) : string {
+    private getSelectedId(options: Array<ILeftNavigationOption>): string {
         const selectedOptions = options.filter(option => { return option.selected ? option.id : null; });
 
         if (selectedOptions.length > 0) {

--- a/src/components/QuickGrid/QuickGrid.Props.ts
+++ b/src/components/QuickGrid/QuickGrid.Props.ts
@@ -17,33 +17,38 @@ export interface IGroupBy {
 }
 
 export interface IQuickGridProps {
+    // required props
     rows: Array<any>;
     columns: Array<GridColumn>;
+
+    // optional props
     groupBy?: Array<string | IGroupBy>;
     gridClassName?: string;
     headerClassName?: string;
     rowHeight?: number | ((info: { index: number }) => number); // Number or a function that returns the height of a row given its index
     overscanRowCount?: number;
-    onSelectedRowChanged?: (selectedRowIndex: number, rowData: any) => void;
-    onRowDoubleClicked?: (row: any) => void;
     displayGroupContainer?: boolean;
     sortColumn?: string;
     sortDirection?: SortDirection;
-    onGroupByChanged?: (groupBy: Array<IGroupBy>) => void;
-    groupRowFormat?: (rowData: any) => string;
-    onGroupBySort?: (sortBy: string, sortDirection: SortDirection) => void;
     gridActions?: QuickGridActions;
     columnSummaries?: any;
     actionsTooltip?: string;
     tooltipsEnabled?: boolean;
     hasCustomRowSelector?: boolean;
-    customRowSorter?: (sortBy, sortDirection) => void;
-    customCellRenderer?: (args: ICustomCellRendererArgs) => React.ReactNode;
     hasStaticColumns?: boolean;
     columnHeadersVisible?: boolean;
     isRowSelectable?: boolean;
     delayMs?: number;
     filterString?: string;
+
+    // callbacks
+    onSelectedRowChanged?: (selectedRowIndex: number, rowData: any) => void;
+    onRowDoubleClicked?: (row: any) => void;
+    customRowSorter?: (sortBy, sortDirection) => void;
+    customCellRenderer?: (args: ICustomCellRendererArgs) => React.ReactNode;
+    onGroupByChanged?: (groupBy: Array<IGroupBy>) => void;
+    groupRowFormat?: (rowData: any) => string;
+    onGroupBySort?: (sortBy: string, sortDirection: SortDirection) => void;
 }
 
 export interface ICustomCellRendererArgs {

--- a/src/components/QuickGrid/QuickGrid.tsx
+++ b/src/components/QuickGrid/QuickGrid.tsx
@@ -313,6 +313,18 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
             }
         };
 
+        if (this.props.customCellRenderer) {
+            return this.props.customCellRenderer({
+                columnIndex,
+                key,
+                rowIndex,
+                style,
+                onMouseEnter: this.onMouseEnterCell,
+                onMouseClick: onClick,
+                rowActionsRender: this.renderRowContextActions,
+                isSelectedRow: rowIndex === this.state.selectedRowIndex
+            });
+        }
 
         let defaultRender = (overridenStyle) => {
             if (rowData.type === 'GroupRow') { // todo Different member - > true
@@ -327,19 +339,6 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
                 return this.renderBodyCell(columnIndex, key, rowIndex, rowData, overridenStyle, onClick);
             }
         };
-
-        if (this.props.customCellRenderer) {
-            return this.props.customCellRenderer({
-                columnIndex,
-                key,
-                rowIndex,
-                style,
-                onMouseEnter: this.onMouseEnterCell,
-                onMouseClick: onClick,
-                rowActionsRender: this.renderRowContextActions,
-                isSelectedRow: rowIndex === this.state.selectedRowIndex
-            });
-        }
 
         return defaultRender(style);
     }
@@ -568,7 +567,7 @@ export class QuickGridInner extends React.Component<IQuickGridProps, IQuickGridS
         if (empty > 0) {
             newColumnWidths[newColumnWidths.length - 1] = newColumnWidths[newColumnWidths.length - 1] + empty;
         }
-        
+
         return newColumnWidths;
     }
 

--- a/src/components/TreeFilter/VirtualizedTreeView.Props.ts
+++ b/src/components/TreeFilter/VirtualizedTreeView.Props.ts
@@ -1,7 +1,6 @@
 import { FilterSelectionEnum, TreeItem, IFilterSelection } from './TreeFilter.Props';
 import { ItemOperator, ILookupTable, TreeLookups } from './TreeItemOperators';
-
-const nullFunc = () => { };
+import { nullFunc } from '../../utilities/common';
 
 export interface IVirtualizedTreeViewProps {
     title?: string;

--- a/src/components/TreeFilter/VirtualizedTreeViewCheckBox.scss
+++ b/src/components/TreeFilter/VirtualizedTreeViewCheckBox.scss
@@ -1,5 +1,8 @@
 @import '../../styles/variables.scss';
 
+$checkbox-transition-duration: 300ms;
+$checkbox-transition-timing: cubic-bezier(.4, 0, .23, 1);
+
 .virtualized-tree-filter-checkbox {
     display: inline-block;
     box-sizing: border-box;
@@ -38,6 +41,9 @@
             top: 2px;
             position: absolute;
             box-sizing: border-box;
+            transition-property: background, border, border-color;
+            transition-duration: $checkbox-transition-duration;
+            transition-timing-function: $checkbox-transition-timing;
         }
         &.is-checked {
             &:before {
@@ -63,5 +69,6 @@
         margin-left: 3px;
         z-index: 100;
         font-size: 10px;
+        pointer-events: none;
     }
 }

--- a/src/components/TreeFilter/VirtualizedTreeViewCheckBox.tsx
+++ b/src/components/TreeFilter/VirtualizedTreeViewCheckBox.tsx
@@ -12,13 +12,14 @@ export interface IVirtualizedTreeViewCheckBoxProps {
     className?: string;
     iconName?: string;
     iconClassName?: string;
+    style?: React.CSSProperties;
     iconTooltipContent?: string;
-    onChange: () => void;
+    onChange: (e: any) => void;
 }
 
 export class VirtualizedTreeViewCheckBox extends React.PureComponent<IVirtualizedTreeViewCheckBoxProps, {}> {
     render() {
-        const { itemId, checked, onChange, text, iconName, iconClassName, iconTooltipContent } = this.props;
+        const { itemId, checked, onChange, text, iconName, iconClassName, iconTooltipContent, style } = this.props;
         const isChecked = checked === CheckStatus.Checked;
 
         const virtualizedTreeClassName = classNames(
@@ -30,7 +31,7 @@ export class VirtualizedTreeViewCheckBox extends React.PureComponent<IVirtualize
         );
 
         return (
-            <div className={virtualizedTreeClassName} onClick={onChange} >
+            <div className={virtualizedTreeClassName} onClick={onChange} style={style}>
                 <input {...isChecked} className={'checkbox-input'} type="checkbox" />
                 {isChecked && <Icon className={'virtualized-tree-filter-checkbox-checkmark'} iconName={'icon-checkmark'} />}
                 <label className={classNames('virtualized-tree-filter-checkbox-label', { 'is-checked': isChecked })} >
@@ -45,3 +46,4 @@ export class VirtualizedTreeViewCheckBox extends React.PureComponent<IVirtualize
         );
     }
 }
+

--- a/src/components/TreeGrid/CellElement.Props.ts
+++ b/src/components/TreeGrid/CellElement.Props.ts
@@ -1,3 +1,5 @@
+import { nullFunc } from '../../utilities/common';
+
 export interface ICellElementProps {
     id: any;
     style?: any;
@@ -11,5 +13,13 @@ export interface ICellElementProps {
     onClick?: any;
     onClickParameter?: {};
     onRowDoubleClicked?: any;
-    element?: any;
+    element?: JSX.Element | Array<JSX.Element>;
 }
+
+export const defaultProps = {
+    onMouseEnter: nullFunc,
+    onMouseLeave: nullFunc,
+    onClick: nullFunc,
+    onRowDoubleClicked: nullFunc,
+    isSelectable: false
+};

--- a/src/components/TreeGrid/CellElement.tsx
+++ b/src/components/TreeGrid/CellElement.tsx
@@ -1,49 +1,45 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import { ICellElementProps } from './CellElement.Props';
-import { autobind } from '../../utilities/autobind';
 
+import { autobind } from '../../utilities/autobind';
+import { Checkbox } from '../Checkbox/Checkbox';
+import { ICellElementProps, defaultProps } from './CellElement.Props';
 
 export class CellElement extends React.PureComponent<ICellElementProps, {}> {
+    public static defaultProps = defaultProps;
 
     @autobind
-    private _onMouseEnter() { 
-        if (this.props.onMouseEnter) {
-            this.props.onMouseEnter(this.props.rowIndex);
-        }
+    private _onMouseEnter() {
+        this.props.onMouseEnter(this.props.rowIndex);
     }
+
     @autobind
-    private _onMouseLeave() { 
-        if (this.props.onMouseLeave) {
-            this.props.onMouseLeave(this.props.rowIndex); 
-        }
+    private _onMouseLeave() {
+        this.props.onMouseLeave(this.props.rowIndex);
     }
+
     @autobind
-    private _onClick(ev) { 
-        if (this.props.onClick) {
-            this.props.onClick(ev, this.props.onClickParameter); 
-        }
+    private _onClick(ev) {
+        this.props.onClick(ev, this.props.onClickParameter);
     }
+
     @autobind
     private _onDoubleClick() {
-        if (this.props.onRowDoubleClicked) {
-            this.props.onRowDoubleClicked(this.props.rowData);
-        }
+        this.props.onRowDoubleClicked(this.props.rowData);
     }
 
-    render() {
-        return(
+    public render() {
+        return (
             <div
-            key={this.props.id}
-            style={this.props.style}
-            className={this.props.className}
-            title={this.props.title}
-            onMouseEnter={this._onMouseEnter}
-            onMouseLeave={this._onMouseLeave}
-            onClick={this._onClick}
-            onDoubleClick={this._onDoubleClick}
+                key={this.props.id}
+                style={this.props.style}
+                className={this.props.className}
+                title={this.props.title}
+                onMouseEnter={this._onMouseEnter}
+                onMouseLeave={this._onMouseLeave}
+                onClick={this._onClick}
+                onDoubleClick={this._onDoubleClick}
             >
-            {this.props.element}
+                {this.props.element}
             </div>
         );
     }

--- a/src/components/TreeGrid/TreeGrid.Props.ts
+++ b/src/components/TreeGrid/TreeGrid.Props.ts
@@ -1,13 +1,13 @@
 import { GridColumn, SortDirection, QuickGridActions } from '../QuickGrid/QuickGrid.Props';
 import { TreeNode, TreeDataSource, IFinalTreeNode } from '../../models/TreeData';
+import { IDictionary } from '../../utilities/common';
 
 export interface ITreeGridProps {
     treeDataSource: TreeDataSource;
     columns: Array<GridColumn>;
+
+    isMultiSelectable?: boolean;
     className?: string;
-    onRowDoubleClicked?: (row: any) => void;    
-    onSelectedNodeChanged?: (selectedNode: IFinalTreeNode) => void;
-    onLazyLoadChildNodes?: (node: IFinalTreeNode) => void;
     gridActions?: QuickGridActions;
     sortColumn?: string;
     sortDirection?: SortDirection;
@@ -16,13 +16,17 @@ export interface ITreeGridProps {
     filterString?: string;
     selectedNodeId?: number;
     isNodeSelectable?: boolean;
+
+    onRowDoubleClicked?: (row: any) => void;
+    onSelectedNodeChanged?: (selectedNode: Array<IFinalTreeNode>) => void;
+    onLazyLoadChildNodes?: (node: IFinalTreeNode) => void;
 }
 
-export interface ITreeGridState {    
+export interface ITreeGridState {
     columnsToDisplay: Array<GridColumn>;
     sortColumn?: string;
     sortDirection?: SortDirection;
     sortRequestId: number;
     structureRequestChangeId: number;
-    selectedNodeId?: number;
+    selectedNodeId?: number | string;
 }

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -1,20 +1,25 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 
+import { CheckStatus } from '../..';
 import { IFinalTreeNode } from '../../models/TreeData';
-import { getTreeRowsSelector } from './TreeGridDataSelectors';
+import { getObjectValue } from '../../utilities/getObjectValue';
 import { Icon } from '../Icon/Icon';
-import { getColumnMinWidth, GridColumn, ICustomCellRendererArgs, IQuickGrid, QuickGrid, DataTypeEnum, BoolFormatTypeEnum } from '../QuickGrid';
+import { DataTypeEnum, getColumnMinWidth, GridColumn, ICustomCellRendererArgs, IQuickGrid, QuickGrid } from '../QuickGrid';
+import { boolFormatterFactory } from '../QuickGrid/CellFormatters';
 import { Spinner } from '../Spinner/Spinner';
 import { SpinnerType } from '../Spinner/Spinner.Props';
+import { VirtualizedTreeViewCheckBox } from '../TreeFilter/VirtualizedTreeViewCheckBox';
 import { CellElement } from './CellElement';
 import { ITreeGridProps, ITreeGridState } from './TreeGrid.Props';
-import { boolFormatterFactory } from '../QuickGrid/CellFormatters';
-import { getObjectValue } from '../../utilities/getObjectValue';
+import { getTreeRowsSelector } from './TreeGridDataSelectors';
+import { nullFunc } from '../../utilities/common';
 
 export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState> {
     public static defaultProps = {
-        isNodeSelectable: true
+        isNodeSelectable: true,
+        isMultiSelectable: false,
+        onSelectedNodeChanged: nullFunc
     };
 
     private _quickGrid: IQuickGrid;
@@ -33,8 +38,9 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         }
     };
 
-    constructor(props: ITreeGridProps) {
+    public constructor(props: ITreeGridProps) {
         super(props);
+
         this.state = {
             columnsToDisplay: this._getTreeColumnsToDisplay(props.columns),
             sortColumn: props.sortColumn,
@@ -48,12 +54,15 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         this._maxExpandedLevel = result.maxExpandedLevel;
     }
 
-    componentDidMount() {
-        const rowIndex = this._finalGridRows.findIndex(e => e.nodeId === this.state.selectedNodeId);
+    public componentDidMount() {
+        const rowIndex = this._finalGridRows.findIndex(e => this.props.treeDataSource.getIdMember(e) === this.state.selectedNodeId);
         this._quickGrid.scrollToRow(rowIndex);
     }
 
-    componentWillMount() {
+    public componentWillMount() {
+        this.props.treeDataSource.subscribe(this);
+        this.props.treeDataSource.registerDataListener(this.props.onSelectedNodeChanged);
+
         if (this.props.isNodeSelectable) {
             if (this.state.selectedNodeId > 0) {
                 this._setSelectedNodeAndState(this.state.selectedNodeId);
@@ -61,12 +70,18 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         }
     }
 
+    public componentWillUnmount() {
+        this.props.treeDataSource.unsubscribe(this);
+        this.props.treeDataSource.removeDataListener(this.props.onSelectedNodeChanged);
+    }
+
     private _getTreeColumnsToDisplay(columns: Array<GridColumn>) {
         let expandedColumns = new Array();
+        const fixedColumnWidth = this.props.isMultiSelectable ? 40 : 16;
         expandedColumns.push({
             isSortable: false,
-            width: 16,
-            minWidth: 16,
+            width: fixedColumnWidth,
+            minWidth: fixedColumnWidth,
             fixedWidth: true
         });
         const replacementFirstColumn: GridColumn = {
@@ -106,16 +121,23 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         }
     }
 
-    treeCellRenderer = (args: ICustomCellRendererArgs) => {
+    private treeCellRenderer = (args: ICustomCellRendererArgs) => {
         let { columnIndex, key, rowIndex, style, onMouseEnter, rowActionsRender, onMouseClick } = args;
         const rowData = this._finalGridRows[rowIndex];
         const rowID: number = rowData.nodeId;
-        let isSelectedRow = this.state.selectedNodeId && this.state.selectedNodeId === rowData.nodeId;
-        const indentSize = 20;
+
+        let isSelectedRow;
+
+        if (this.props.isMultiSelectable) {
+            isSelectedRow = this.props.treeDataSource.SelectedNodes[rowData.nodeId];
+        } else {
+            isSelectedRow = this.state.selectedNodeId && this.state.selectedNodeId === this.props.treeDataSource.getIdMember(rowData);
+        }
+
+        const indentSize = this.props.isMultiSelectable ? 30 : 20;
         let indent = 0;
         let level = rowData.nodeLevel;
         if ((columnIndex === 0 || columnIndex === 1)) {
-
             indent = level * indentSize;
         }
         let shouldIndent: boolean = false;
@@ -152,21 +174,76 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         return (
             <div key={key} style={style}>
                 {rowData}
-            </div>);
+            </div>
+        );
+    }
+
+    private getCheckStatus = (data: IFinalTreeNode): CheckStatus => {
+        const nodeId = this.props.treeDataSource.getIdMember(data);
+
+        if (this.props.treeDataSource.PartiallySelectedNodes[nodeId]) {
+            return CheckStatus.ChildChecked;
+        }
+
+        const selectedNodes = this.props.treeDataSource.SelectedNodes;
+        if (!selectedNodes.hasOwnProperty(nodeId)) {
+            return CheckStatus.NotChecked;
+        }
+        if (this.props.treeDataSource.SelectedNodes[nodeId]) {
+            return CheckStatus.Checked;
+        }
     }
 
     private _renderExpandCollapseButton(key, rowIndex: number, rowData: IFinalTreeNode, style, onMouseEnter, isSelectedRow: boolean) {
         const showNodeAsExpanded = rowData.isExpanded || rowData.descendantSatisfiesFilterCondition;
         let actionsTooltip = showNodeAsExpanded ? 'Collapse' : 'Expand';
-        let iconName = showNodeAsExpanded ? 'svg-icon-arrowCollapse' : 'svg-icon-arrowExpand';
+        let iconName = showNodeAsExpanded ? 'icon-arrow_down_right' : 'icon-arrow_right';
         let icon = null;
+
+        const nodeId = this.props.treeDataSource.getIdMember(rowData);
 
         if ((!rowData.children || rowData.children.length <= 0) && !rowData.hasChildren) {
             icon = null;
             actionsTooltip = null;
         } else {
-            icon = <Icon iconName={iconName} className="expand-collapse-action-icon" />;
+            icon = (
+                <Icon
+                    iconName={iconName}
+                    style={{ display: 'inline-block' }}
+                    className="expand-collapse-action-icon"
+                    onClick={(ev) => { ev.stopPropagation(); this._onTreeExpandToggleClick(ev, rowData); }}
+                    title={actionsTooltip}
+                />
+            );
         }
+
+        const onChange = (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+
+            if (this.props.treeDataSource.SelectedNodes[nodeId]) {
+                this.props.treeDataSource.removeSelected(rowData);
+            } else {
+                this.props.treeDataSource.setSelected(rowData);
+            }
+        };
+
+        let checkBox: JSX.Element = null;
+        if (this.props.isMultiSelectable) {
+            const checked = this.props.treeDataSource.SelectedNodes.hasOwnProperty(nodeId);
+            checkBox = (
+                <VirtualizedTreeViewCheckBox
+                    checked={this.getCheckStatus(rowData)}
+                    onChange={onChange}
+                    itemId={nodeId.toString()}
+                    text=""
+                    style={{ paddingTop: '0px' }}
+                />
+            );
+        }
+
+        const elements: Array<JSX.Element> = [checkBox, icon];
+
         const rowClass = 'grid-row-' + rowIndex;
         const title = actionsTooltip;
         const className = classNames(
@@ -175,20 +252,19 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
             rowClass,
             { 'is-selected': isSelectedRow }
         );
+
         return (
             <CellElement
                 key={key}
                 id={key}
                 style={style}
                 className={className}
-                title={title}
                 onMouseEnter={onMouseEnter}
-                onClick={icon ? this._onTreeExpandToggleClick : null}
                 onClickParameter={rowData}
                 rowClass={rowClass}
                 rowData={rowData}
                 rowIndex={rowIndex}
-                element={icon}
+                element={elements}
             />
         );
     }
@@ -224,15 +300,12 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         };
         onCellClick = rowData.isAsyncLoadingDummyNode ? undefined : onCellClick;
         if (rowData.isAsyncLoadingDummyNode && columnIndex === 1) {
-            columnElement = <div className="loading-container">
-                <Spinner className="async-loading-spinner"
-                    type={SpinnerType.small}
-                />
-                <span className="async-loading-label">
-                    Loading...
-                    </span>
-            </div>;
-
+            columnElement = (
+                <div className="loading-container">
+                    <Spinner className="async-loading-spinner" type={SpinnerType.small} />
+                    <span className="async-loading-label">Loading...</span>
+                </div>
+            );
         } else if (column.cellFormatter) {
             columnElement = column.cellFormatter(cellData, rowData);
         } else {
@@ -293,25 +366,24 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
     }
 
     private _setSelectedNode = (rowIndex: number, nodeData: IFinalTreeNode) => {
-        if (this.state.selectedNodeId === nodeData.nodeId) {
-            return;
-        }
-        this.setState({ selectedNodeId: nodeData.nodeId });
-        if (this.props.onSelectedNodeChanged) {
-            this.props.onSelectedNodeChanged(this._finalGridRows[rowIndex]);
-        }
-    }
-
-    private _setSelectedNodeAndState = (nodeId: number) => {
+        const nodeId = this.props.treeDataSource.getIdMember(nodeData);
         if (this.state.selectedNodeId === nodeId) {
             return;
         }
         this.setState({ selectedNodeId: nodeId });
 
-        if (this.props.onSelectedNodeChanged) {
-            const selectedNode = this._finalGridRows.find((element) => { return element.nodeId === nodeId; });
-            this.props.onSelectedNodeChanged(selectedNode);
+        this.props.onSelectedNodeChanged([this._finalGridRows[rowIndex]]);
+    }
+
+    private _setSelectedNodeAndState = (nodeId: number | string) => {
+        if (this.state.selectedNodeId === nodeId) {
+            return;
         }
+        this.setState({ selectedNodeId: nodeId });
+
+        const selectedNode = this._finalGridRows.find((element) => { return element.nodeId === nodeId; });
+        this.props.onSelectedNodeChanged([selectedNode]);
+
         const selectedRowIndex = this._finalGridRows.findIndex((element) => element.nodeId === nodeId);
 
         this._quickGrid.scrollToRow(selectedRowIndex);

--- a/src/models/TreeData.ts
+++ b/src/models/TreeData.ts
@@ -1,3 +1,8 @@
+import * as _ from 'lodash';
+import { IDictionary } from '../utilities/common';
+import { IObservable } from '../utilities/observable';
+import { removeLookupEntry, addLookupEntry } from '../utilities/immutable';
+
 export interface TreeNode { // extend this interface on a data structure to be used for row data    
     isExpanded?: boolean;
     children?: Array<TreeNode>;
@@ -26,6 +31,14 @@ export interface ILookupTable {
     [id: number]: IFinalTreeNode;
 }
 
+export type IdGetter = (node: TreeNode) => string | number;
+
+export type SelectedIdListener = (selectedIds: Array<string>) => void;
+
+export type DataListener = (selectedIds: Array<IFinalTreeNode>) => void;
+
+const defaultIdMember = (node: IFinalTreeNode) => node.nodeId;
+
 /**
  * This class is meant to work with th TreeGrid component.
  * This class breaks the immutability principle of redux
@@ -37,9 +50,55 @@ export interface ILookupTable {
  * this allows us to view the TreeDataSource as immutable when performing actions in our reducers
  * ie. we add a new child to the tree, react will register the change and the TreeGrid component will update because of the prop change
  */
-export class TreeDataSource {
-    public nodesById: ILookupTable;
+export class TreeDataSource implements IObservable<React.Component> {
+    private subscribers: Array<React.Component> = [];
+    private dataListeners: Array<DataListener> = [];
+    private selectedIdsListeners: Array<SelectedIdListener> = [];
+
+    public enableRecursiveSelection: boolean;
+
+    public subscribe(listener: React.Component<{}, {}>): void {
+        this.subscribers.push(listener);
+    }
+
+    public unsubscribe(listener: React.Component<{}, {}>): void {
+        const index = this.subscribers.findIndex(l => Object.is(listener, l));
+        this.subscribers.slice(index, 1);
+    }
+
+    public registerDataListener = (dataListener: DataListener) => {
+        this.dataListeners.push(dataListener);
+    }
+
+    public removeDataListener = (dataListener: DataListener) => {
+        const index = this.subscribers.findIndex(l => Object.is(dataListener, l));
+        this.dataListeners.slice(index, 1);
+    }
+
+    public registerSelectedIdsListener = (selectedIdsListener: SelectedIdListener) => {
+        this.selectedIdsListeners.push(selectedIdsListener);
+    }
+
+    private notifyWithSelectedIds = () => {
+        const selectedIds = Object.keys(this.selectedIds);
+        this.selectedIdsListeners.forEach(selectedIdListener => selectedIdListener(selectedIds));
+    }
+
+    private notifyWithSelectedNodes = () => {
+        const selectedIds = Object.keys(this.selectedIds);
+        const nodes = selectedIds.map(id => this.nodesById[id] as IFinalTreeNode);
+        this.dataListeners.forEach(dataListener => dataListener(nodes));
+    }
+
+    public setRecursiveSelection(isEnabled: boolean) {
+        this.enableRecursiveSelection = isEnabled;
+        this.updateSelectStrategy(isEnabled);
+    }
+
+    public notify = () => this.subscribers.forEach(l => l.forceUpdate());
+
     private idCounter: number = 0;
+
     // this would constitute a really dirty hack
     // React shallow compares each prop that is an object before even calling ShouldComponentUpdate    
     // To force react to event consider updating a component(event if it is not pure) we need to pass an object that has some change
@@ -47,28 +106,268 @@ export class TreeDataSource {
     private changeIteration: number = 0;
     private treeStructure: IFinalTreeNode;
     public isEmpty: boolean;
+
+    /** Lookup that holds parent object for given node */
+    // private parentLookup: ILookupTable;
+
+    /** Lookup that returns node object for given node id */
+    private nodesById: ILookupTable;
+
+    private idMember: string | IdGetter;
+
+    // items used for row selection
+    private selectedIds: IDictionary<boolean>;
+    private partiallySelectedIds: IDictionary<boolean>;
+
+    private _selectItemsStrategy: (item: IFinalTreeNode) => void;
+    private _removeItemsStrategy: (item: IFinalTreeNode) => void;
+
+
+    get SelectedNodes(): IDictionary<boolean> {
+        return this.selectedIds;
+    }
+
+    get PartiallySelectedNodes(): IDictionary<boolean> {
+        return this.partiallySelectedIds;
+    }
+
+    public setSelectedIds(items: Array<number | string>) {
+        this.selectedIds = {};
+        this.partiallySelectedIds = {};
+
+        if (items.length === 0) {
+            this.notifyWithSelectedNodes();
+            this.notify();
+        }
+
+        items.forEach(i => this._selectItemsStrategy(this.nodesById[i]));
+    }
+
+    public selectAll() {
+        this.updateSelectedItems(this.treeStructure);
+    }
+
+    public deselectAll() {
+        this.removeSelectedItems(this.treeStructure);
+    }
+
     /**
      * 
      * @param root warning: will be mutated and returned as ITreeDataSource
      */
-    constructor(input: TreeNode | TreeDataSource | Array<any>) {
+    constructor(
+        input: TreeNode | TreeDataSource | Array<any>,
+        idMember: (string | IdGetter) = defaultIdMember,
+        enableRecursiveSelection: boolean = true,
+        selectedNodes: Array<number | string> = []
+    ) {
+        this.updateSelectStrategy(enableRecursiveSelection);
+
+        this.idMember = idMember;
+        this.partiallySelectedIds = {};
+        this.selectedIds = {};
+
         if (this.isDataSource(input)) {
             this.nodesById = input.nodesById;
             this.idCounter = input.idCounter;
             this.treeStructure = input.treeStructure;
             this.changeIteration = input.changeIteration + 1;
+            this.selectedIds = input.selectedIds;
+            this.partiallySelectedIds = input.partiallySelectedIds;
+            this.enableRecursiveSelection = input.enableRecursiveSelection;
+            this.updateSelectStrategy(input.enableRecursiveSelection);
+            this.idMember = input.idMember;
+            this.dataListeners = input.dataListeners;
+            this.subscribers = input.subscribers;
+            this.selectedIdsListeners = input.selectedIdsListeners;
         } else {
-            let rootNode: TreeNode;
-            if (this.isRootNodesArray(input)) {
-                rootNode = { children: input };
-            } else {
-                rootNode = input;
-            }
+            let rootNode: TreeNode = this.isRootNodesArray(input) ? { children: input } : input;
             this.nodesById = {};
             this.extendNodes(input, rootNode.children, 0);
             this.treeStructure = <IFinalTreeNode>rootNode;
             this.isEmpty = this.treeStructure.children.length === 0;
+            this.setSelectedIds(selectedNodes);
         }
+    }
+
+    public setSelected(item: IFinalTreeNode) {
+        this._selectItemsStrategy(item);
+    }
+
+    public removeSelected(item: IFinalTreeNode) {
+        this._removeItemsStrategy(item);
+    }
+
+    /**
+     * Returns unique parameter for given node.
+     */
+    public getIdMember = (node: TreeNode): string | number => {
+        if (typeof this.idMember === 'function') {
+            return this.idMember(node);
+        }
+
+        if (!node.hasOwnProperty(this.idMember)) {
+            throw Error('Object doesn\'t have specified property for given key.');
+        }
+
+        return node[this.idMember];
+    }
+
+    private updateSelectStrategy(enableRecursiveSelection: boolean) {
+        this.enableRecursiveSelection = enableRecursiveSelection;
+        if (enableRecursiveSelection) {
+            this._removeItemsStrategy = this.removeSelectedItems;
+            this._selectItemsStrategy = this.updateSelectedItems;
+        } else {
+            this._removeItemsStrategy = this.removeSelectedItem;
+            this._selectItemsStrategy = this.setSelectedItem;
+        }
+    }
+
+    private updateSelectedItems = (node: IFinalTreeNode) => {
+        // get all selected items from this node up to all children
+        const selectedIds = this.checkRecursive(node);
+
+        // merge old selected items and new selected items
+        this.selectedIds = { ...this.selectedIds, ...selectedIds };
+
+        const nodeId = this.getIdMember(node);
+
+        // if it was partially selected before, remove it from partial selection
+        if (this.partiallySelectedIds.hasOwnProperty(nodeId)) {
+            this.partiallySelectedIds = removeLookupEntry(nodeId, this.partiallySelectedIds);
+        }
+
+        if (this.checkObject(node.parent) && this.getIdMember(node.parent) !== undefined) {
+            this.checkIfAllChildrenAreSelected(node.parent, nodeId, selectedIds);
+        }
+
+        this.notifyWithSelectedNodes();
+        this.notify();
+    }
+
+    private partiallySelectItem = (node: IFinalTreeNode) => {
+        const nodeId = this.getIdMember(node);
+        this.selectedIds = removeLookupEntry(nodeId, this.selectedIds);
+        this.partiallySelectedIds = addLookupEntry(nodeId, true, this.partiallySelectedIds);
+
+        if (!this.checkObject(node.parent)) {
+            return;
+        }
+
+        this.partiallySelectItem(node.parent);
+    }
+
+    private checkIfAllChildrenAreSelected = (
+        node: IFinalTreeNode,
+        childNodeId: number | string,
+        nodeChildrenSubset: IDictionary<boolean>
+    ) => {
+        const nodeId = this.getIdMember(node);
+        const allChildren = { ...this.checkRecursive(node, false, { [childNodeId]: true }), ...nodeChildrenSubset };
+        const allChildrenKeys = Object.keys(allChildren);
+        const allSelectedItemKeys = Object.keys(this.selectedIds);
+        const diff = _.difference(allChildrenKeys, allSelectedItemKeys);
+
+        if (diff.length === allChildrenKeys.length) {
+            this.partiallySelectedIds = removeLookupEntry(nodeId, this.partiallySelectedIds);
+            if (this.checkObject(node.parent) && this.getIdMember(node.parent) !== undefined) {
+                this.checkIfAllChildrenAreSelected(node.parent, nodeId, allChildren);
+            }
+        } else if (diff.length === 0) {
+            this.partiallySelectedIds = removeLookupEntry(nodeId, this.partiallySelectedIds);
+            this.selectedIds = addLookupEntry(nodeId, true, this.selectedIds);
+
+            if (this.checkObject(node.parent) && this.getIdMember(node.parent) !== undefined) {
+                this.checkIfAllChildrenAreSelected(node.parent, nodeId, allChildren);
+            }
+        } else {
+            this.selectedIds = removeLookupEntry(nodeId, this.selectedIds);
+            this.partiallySelectItem(node);
+        }
+    }
+
+    private removeSelectedItems = (node: IFinalTreeNode) => {
+        const selectedIds = this.checkRecursive(node);
+        const keysToRemove = Object.keys(selectedIds);
+        const oldKeys = Object.keys(this.selectedIds);
+        const newSelected = _.without(oldKeys, ...keysToRemove);
+        const newSelectedDict = {};
+        for (let i = 0; i < newSelected.length; i++) {
+            newSelectedDict[newSelected[i]] = true;
+        }
+        this.selectedIds = { ...newSelectedDict };
+
+        if (this.checkObject(node.parent) && this.getIdMember(node.parent) !== undefined) {
+            this.checkIfAllChildrenAreSelected(node.parent, this.getIdMember(node), selectedIds);
+        }
+
+        this.notifyWithSelectedNodes();
+        this.notify();
+    }
+
+    private removeSelectedItem = (node: TreeNode) => {
+        const nodeId = this.getIdMember(node);
+        this.selectedIds = removeLookupEntry(nodeId, this.selectedIds);
+
+        this.notifyWithSelectedNodes();
+        this.notify();
+    }
+
+    private setSelectedItem = (node: TreeNode) => {
+        const nodeId = this.getIdMember(node);
+        this.selectedIds = addLookupEntry(nodeId, true, this.selectedIds);
+
+        this.notifyWithSelectedNodes();
+        this.notify();
+    }
+
+    private checkObject = (obj: any): boolean => {
+        if (obj === undefined || obj === null) {
+            return false;
+        }
+        return true;
+    }
+
+    private checkRecursive = (node: IFinalTreeNode, appendParentNode: boolean = true, skipItems: IDictionary<boolean> = {}) => {
+        const selectedIds = {};
+        this.recursiveChildSelection(selectedIds, node, appendParentNode, skipItems);
+        return selectedIds;
+    }
+
+    /**
+     * Return lookup table off all child ids
+     */
+    private recursiveChildSelection = (
+        selectedIds: IDictionary<boolean>,
+        node: IFinalTreeNode,
+        appendParentNode: boolean = true,
+        skipItems: IDictionary<boolean> = {}
+    ): void => {
+        if (appendParentNode) {
+            const nodeId = this.getIdMember(node);
+            selectedIds[nodeId] = true;
+        }
+
+        if (!this.itemHasChildren(node)) {
+            return;
+        }
+
+        for (let child of node.children) {
+            const childId = this.getIdMember(child);
+            if (skipItems[childId]) {
+                continue;
+            }
+            selectedIds[childId] = true;
+            this.recursiveChildSelection(selectedIds, child, false, skipItems);
+        }
+    }
+
+    private itemHasChildren = (item: TreeNode) => {
+        if (!this.checkObject(item.children)) {
+            return false;
+        }
+        return item.children.length !== 0;
     }
 
     private extendNodes(parent, children: Array<TreeNode>, level: number) {
@@ -123,10 +422,15 @@ export class TreeDataSource {
                 existingNode.hasChildren = props.children && props.children.length > 0;
                 existingNode.isExpanded = existingNode.isExpanded && existingNode.hasChildren;
                 this.extendNodes(existingNode, existingNode.children, existingNode.nodeLevel + 1);
+
+                if (this.selectedIds[nodeId] && this.enableRecursiveSelection) {
+                    this.setSelected(existingNode);
+                }
             }
             this.isEmpty = this.treeStructure.children.length === 0;
             return new TreeDataSource(this);
         }
+
         return this;
     }
 

--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -1,0 +1,5 @@
+export const nullFunc = () => { };
+
+export type IDictionary<T> = {
+    [id: number]: T
+};

--- a/src/utilities/immutable.ts
+++ b/src/utilities/immutable.ts
@@ -1,0 +1,24 @@
+import { IDictionary } from './common';
+
+/**
+* Removes given key from lookup and returns new lookup instance.
+* @param entryKey Lookup key
+* @param dictionary Lookup
+*/
+export const removeLookupEntry = <T>(entryKey: string | number, dictionary: IDictionary<T>): IDictionary<T> => {
+    const _clone = { ...dictionary };
+    delete _clone[entryKey];
+    return _clone;
+};
+
+/**
+ * Add new item to lookup and returns new lookup instance.
+ * @param entryKey Lookup key
+ * @param item Item to add to lookup
+ * @param dictionary Lookup
+ */
+export const addLookupEntry = <T>(entryKey: string | number, item: T, dictionary: IDictionary<T>): IDictionary<T> => {
+    const _clone = { ...dictionary };
+    _clone[entryKey] = item;
+    return _clone;
+};

--- a/src/utilities/observable.ts
+++ b/src/utilities/observable.ts
@@ -1,0 +1,5 @@
+export interface IObservable<T> {
+    subscribe(listener: T): void;
+    unsubscribe(listener: T): void;
+    notify(): void;
+}


### PR DESCRIPTION
### **** After PR for Refactor ****

Multiselect implementation on TreeGrid and TreeDataSource.

Node updating works as before, every time structure is updated new reference on TreeDataSource is returned which will force re-rendering.

Multiselect works a bit different, because of complex logic which would be difficult to implement from the outside, everything is hold inside TreeDataSource. Data source can be multiselected with or without recursive strategy. If recursive strategy is used, every child of selected node will be selected. Updating works in a way where tree grid is "registered" in data source, and is forced to re-render when selection is  changed. When selection is changed grid will be re-rendered and callback on TreeGrid will be fired which will return array of selected objects. Every time when we need to, we can replace selected items from the outside with method on data source, but this implementation of selection doesn't force user to provide selected items from outside every time, but gives that information to consumer on every selection change. This means that consumer can always know what items are selected, but isn't obligated to provide it programatically from inside.