### PR TITLE
Tooltips enabled in TreeGrid header

### DIFF
--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -395,7 +395,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
                 gridActions={this.props.gridActions}
                 sortDirection={this.state.sortDirection}
                 sortColumn={this.state.sortColumn}
-                tooltipsEnabled={false}
+                tooltipsEnabled={true}
                 customCellRenderer={this.treeCellRenderer}
                 hasCustomRowSelector={true}
                 hasStaticColumns={true}


### PR DESCRIPTION
By setting tooltipsEnabled to true it is propagated down to QuickGrid header and tooltips are enabled