### PR TITLE
VirtualizedTreeView fix for search + select all

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "quick-react-ts",
-    "version": "0.11.6",
+    "version": "0.11.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/components/TreeFilter/VirtualizedTreeView.Props.ts
+++ b/src/components/TreeFilter/VirtualizedTreeView.Props.ts
@@ -18,7 +18,7 @@ export interface IVirtualizedTreeViewProps {
     onValuesSelected?: (filterId: string, filterSelection: IFilterSelection) => void;
     defaultSelection?: FilterSelectionEnum;
     rowHeight?: number;
-    onItemsSearch?: (query: string) => void;
+    onItemsSearch?: (query: string, newItems: any) => void;
     searchQuery?: string;
     allItemIdsGetter?: (items?: Array<TreeItem>) => ReadonlyArray<string>;
     lookupTableGetter?: (items?: Array<TreeItem>) => any;
@@ -49,4 +49,5 @@ export interface IVirtualizedTreeViewState {
     searchText: string;
     partiallyCheckedItemIds: Array<string>;
     scrollToIndex: number;
+    searchedItemList: Array<TreeItem>;
 }


### PR DESCRIPTION
We had problem in this scenario:
- we search item in list 
- then click checkbox to select all
- then click checkbox to deselect all => show full list and ignore search

I fixed it in way that onSearch() method return searched list, also I added property in state searchedItemList so I can compare in ComponentWillRecieveProps which list we need to show.