### PR TITLE
fixed some problems with the treegrid component

### DIFF
--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -379,8 +379,12 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         this.setState({ selectedNodeId: nodeId });
 
         if (this.props.onSelectedNodeChanged) {
-            const selectedNode = this._finalGridRows.find((element) => { return element.$meta.nodeId === nodeId; });
-            this.props.onSelectedNodeChanged([selectedNode]);
+            const selectedNode = this.props.treeDataSource.getNodeById(nodeId);
+            if (selectedNode) {
+                this.props.onSelectedNodeChanged([selectedNode]);
+            } else {
+                this.props.onSelectedNodeChanged([]);
+            }
         }
         const selectedRowIndex = this._finalGridRows.findIndex((element) => element.$meta.nodeId === nodeId);
 

--- a/src/models/TreeData.ts
+++ b/src/models/TreeData.ts
@@ -197,10 +197,10 @@ export class TreeDataSource<T = {}>  implements IObservable<React.Component> {
 
             // if the children will be replaced, we need to remove the old ids
             if (props.children && existingNode.children && existingNode.children.length > 0) {
-                const removeChildrenFromLookup = (node) => {
+                const removeChildrenFromLookup = (node: AugmentedTreeNode) => {
                     if (node && node.children) {
                         for (let i = 0; i < node.children.length; i++) {
-                            delete this.nodesById[node.children[i].nodeId];
+                            delete this.nodesById[node.children[i].$meta.nodeId];
                             removeChildrenFromLookup(node.children[i]);
                         }
                     }


### PR DESCRIPTION
Typescript is great.... at least when using the type part of it 😢 . Anyhow there are two fixes here for bugs that manifested after the $meta and multiselect PRs:
1. when updating children of a node the old child nodes stayed in the node lookup because it nodeId returned undefined so nothing was deleted from the lookup. This created problems with selection after node refresh and i imagine some other unforseen stuff.
2. selectedNodes array would sometimes be [undefined] if a node with selectedNodeId was not found.