### PR TITLE
TreeGrid Multiselect with recursive selection fixes

### DIFF
--- a/src/models/TreeData.ts
+++ b/src/models/TreeData.ts
@@ -56,7 +56,7 @@ export type DataListener = (selectedIds: Array<AugmentedTreeNode>) => void;
  * this allows us to view the TreeDataSource as immutable when performing actions in our reducers
  * ie. we add a new child to the tree, react will register the change and the TreeGrid component will update because of the prop change
  */
-export class TreeDataSource<T = {}>  implements IObservable<React.Component> {
+export class TreeDataSource<T = {}> implements IObservable<React.Component> {
     private idCounter: number = 0;
 
     // this would constitute a really dirty hack
@@ -96,7 +96,7 @@ export class TreeDataSource<T = {}>  implements IObservable<React.Component> {
             this.idCounter = input.idCounter;
             this.treeStructure = <AugmentedTreeNode<T>>input.treeStructure;
             this.changeIteration = input.changeIteration + 1;
-            this.idMember = input.idMember || idMember;   
+            this.idMember = input.idMember || idMember;
             this.selectedIds = input.selectedIds;
             this.partiallySelectedIds = input.partiallySelectedIds;
             this.enableRecursiveSelection = input.enableRecursiveSelection;
@@ -254,7 +254,7 @@ export class TreeDataSource<T = {}>  implements IObservable<React.Component> {
         }
         return undefined;
     }
-    
+
 
     private subscribers: Array<React.Component> = [];
     private dataListeners: Array<DataListener> = [];
@@ -262,7 +262,7 @@ export class TreeDataSource<T = {}>  implements IObservable<React.Component> {
 
     public enableRecursiveSelection: boolean;
 
-     // items used for row selection
+    // items used for row selection
     private selectedIds: IDictionary<boolean>;
     private partiallySelectedIds: IDictionary<boolean>;
 
@@ -477,13 +477,16 @@ export class TreeDataSource<T = {}>  implements IObservable<React.Component> {
      */
     private recursiveChildSelection = (
         selectedIds: IDictionary<boolean>,
-        node: TreeNode,
+        node: AugmentedTreeNode,
         appendParentNode: boolean = true,
         skipItems: IDictionary<boolean> = {}
     ): void => {
         if (appendParentNode) {
             const nodeId = this.getNodeId(node);
             selectedIds[nodeId] = true;
+            if (this.partiallySelectedIds.hasOwnProperty(nodeId)) {
+                this.partiallySelectedIds = removeLookupEntry(nodeId, this.partiallySelectedIds);
+            }
         }
 
         if (!this.itemHasChildren(node)) {
@@ -496,7 +499,10 @@ export class TreeDataSource<T = {}>  implements IObservable<React.Component> {
                 continue;
             }
             selectedIds[childId] = true;
-            this.recursiveChildSelection(selectedIds, child, false, skipItems);
+            if (this.partiallySelectedIds.hasOwnProperty(childId)) {
+                this.partiallySelectedIds = removeLookupEntry(childId, this.partiallySelectedIds);
+            }
+            this.recursiveChildSelection(selectedIds, child as AugmentedTreeNode, false, skipItems);
         }
     }
 }

--- a/src/models/TreeData.ts
+++ b/src/models/TreeData.ts
@@ -408,6 +408,7 @@ export class TreeDataSource<T = {}> implements IObservable<React.Component> {
 
         if (diff.length === allChildrenKeys.length) {
             this.partiallySelectedIds = removeLookupEntry(nodeId, this.partiallySelectedIds);
+            this.selectedIds = removeLookupEntry(nodeId, this.selectedIds);
             if (this.checkObject(node.parentNode) && this.getNodeId(node.parentNode) !== undefined) {
                 this.checkIfAllChildrenAreSelected(node.parentNode, nodeId, allChildren);
             }

--- a/src/models/TreeData.ts
+++ b/src/models/TreeData.ts
@@ -494,8 +494,9 @@ export class TreeDataSource<T = {}> implements IObservable<React.Component> {
         }
 
         for (let child of node.children) {
+            let augmentedChild = child as AugmentedTreeNode;
             const childId = this.getNodeId(child);
-            if (skipItems[childId]) {
+            if (skipItems[childId] || !this.isVisibleWhenFiltered(augmentedChild)) {
                 continue;
             }
             selectedIds[childId] = true;
@@ -504,5 +505,12 @@ export class TreeDataSource<T = {}> implements IObservable<React.Component> {
             }
             this.recursiveChildSelection(selectedIds, child as AugmentedTreeNode, false, skipItems);
         }
+    }
+
+    private isVisibleWhenFiltered = (node: AugmentedTreeNode): boolean => {
+        if (node.$meta.satisfiesFilterCondition !== undefined && !node.$meta.satisfiesFilterCondition && !node.$meta.descendantSatisfiesFilterCondition) {
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
Tree Grid had a problem with checking and unchecking rows when recursive selection was enabled. 
- Fixed partially selected parent node problem with select/deselect all
- Fix a problem on deselecting of only child
- Added logic for selecting only visible nodes when filtered text is applied