### PR TITLE
disabled nodes functionality

### DIFF
--- a/src/components/QuickGrid/QuickGrid.scss
+++ b/src/components/QuickGrid/QuickGrid.scss
@@ -172,6 +172,11 @@
             &.is-selected {
                 background-color: $selected-item-background;
             }
+
+            &.is-disabled {
+                opacity: 0.5;
+                pointer-events: none;
+            }
             
             .center-icon {
                 display: block;

--- a/src/components/TreeGrid/TreeGrid.tsx
+++ b/src/components/TreeGrid/TreeGrid.tsx
@@ -225,7 +225,7 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
         };
 
         let checkBox: JSX.Element = null;
-        if (this.props.isMultiSelectable) {
+        if (this.props.isMultiSelectable && !rowData.isNodeDisabled) {
             const checked = this.props.treeDataSource.SelectedNodes.hasOwnProperty(nodeId);
             checkBox = (
                 <VirtualizedTreeViewCheckBox
@@ -246,7 +246,11 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
             'grid-component-cell',
             'expand-collapse-cell',
             rowClass,
-            { 'is-selected': isSelectedRow && this.props.highlightRowsInMultiSelect }
+            {
+                'is-selected': isSelectedRow && this.props.highlightRowsInMultiSelect && !rowData.isNodeDisabled,
+                'is-disabled': rowData.isNodeDisabled
+            }
+
         );
 
         return (
@@ -278,8 +282,11 @@ export class TreeGrid extends React.PureComponent<ITreeGridProps, ITreeGridState
             rowClass,
             column.cellClassName,
             rowData.className,
-            { 'border-column-cell': notLastIndex },
-            { 'is-selected': isSelectedRow && this.props.highlightRowsInMultiSelect });
+            {
+                'border-column-cell': notLastIndex,
+                'is-selected': isSelectedRow && this.props.highlightRowsInMultiSelect && !rowData.isNodeDisabled,
+                'is-disabled': rowData.isNodeDisabled
+            });
 
         let columnElement: any;
         let onCellClick = (e) => {

--- a/src/models/TreeData.ts
+++ b/src/models/TreeData.ts
@@ -11,6 +11,7 @@ export interface TreeNode { // extend this interface on a data structure to be u
     iconTooltipContent?: string;
     iconClassName?: string;
     className?: string;
+    isNodeDisabled?: boolean;
 }
 
 export type AugmentedTreeNode<T = {}> = TreeNode & T & {


### PR DESCRIPTION
I needed to disable some nodes that were shown in the TreeGrid. Not sure if i should maybe put isNodeDisabled inside $meta. If i do, it is cleaner and it cannot be used by mistake(i.e. there is a property in the C# classes that is named nodedisabled, what if i did not remember this fact). If i do put it there i can't just use it without additional logic.