### PR TITLE
fix for undefined when selectall is used

### DIFF
--- a/src/models/TreeData.ts
+++ b/src/models/TreeData.ts
@@ -496,7 +496,7 @@ export class TreeDataSource<T = {}> implements IObservable<React.Component> {
         appendParentNode: boolean = true,
         skipItems: IDictionary<boolean> = {}
     ): void => {
-        if (appendParentNode) {
+        if (appendParentNode && node !== this.treeStructure) {
             const nodeId = this.getNodeId(node);
             selectedIds[nodeId] = true;
             if (this.partiallySelectedIds.hasOwnProperty(nodeId)) {


### PR DESCRIPTION
When using the select all functionality the resulting selected nodes array would contain undefined as the last element. This as you can imagine can cause problems.