### PR TITLE
flexible iconName

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -40,8 +40,14 @@ export const Icon: (props: IIconProps) => JSX.Element = (props: IIconProps) => {
     }
 
     if (svgIcon) {
+        const spaceIdx= props.iconName.indexOf(' ');
+        let iconName = props.iconName;
+        if(spaceIdx !== -1) {
+            iconName = props.iconName.substr(0, spaceIdx);
+        }
+
         return <svg { ...getNativeAttributes(props, htmlElementAttributes) } className={iconClassName} width={iconWidth} height={iconHeight}>
-            <use xlinkHref={'#symbol-defs_' + props.iconName} />
+            <use xlinkHref={'#symbol-defs_' + iconName} />
         </svg>;
     } else {
         return <i { ...getNativeAttributes(props, htmlElementAttributes) } className={iconClassName} />;


### PR DESCRIPTION
Before we moved to svg you could just write iconName="font-name something something" and it would work. With svg it was not working because the svg element with that name could not be found.

One could argue that the iconName should strictly be to identify the icon name and iconName should have never been added to the classList(line 12). BUT, it is much simpler to work with a single property than with both iconName and iconClassName, especially when the only way to color an svg is to add another class. 
Lets say you used an icon on multiple places but now you need to  color it conditionally. 
Option 1) just add the changes to the css and add it to the iconName (as you would for non-svg)
Option 2) track down where you function that maps your icons based on some conditions is used and refactor it to return {iconname, iconClass}
I like option 1.