### PR TITLE
fixed a bug with the searchbox in the treefilter component

### DIFF
--- a/src/components/TreeFilter/TreeFilter.tsx
+++ b/src/components/TreeFilter/TreeFilter.tsx
@@ -137,7 +137,9 @@ export class TreeFilter extends React.PureComponent<ITreeFilterProps, ITreeFilte
     }
 
     private onDismiss = () => {
-        this.setState(prevState => ({ ...prevState, isOpen: false }));
+        this.setState(prevState => ({ ...prevState, 
+            isOpen: false,
+            query: this.props.clearSearchOnClose ? '' : prevState.query, }));
         this.props.onCalloutClose();
     }
 
@@ -174,7 +176,7 @@ export class TreeFilter extends React.PureComponent<ITreeFilterProps, ITreeFilte
         const isDefault = this.checkIfDefaultSelection(filterSelection.type, filterSelection.selectedIDs);
         let state = { ...this.state, isDefaultSelected: isDefault, selection: filterSelection };
         if (this.props.isSingleSelect) {
-            state = { ...state, isOpen: false };
+            state = { ...state, isOpen: false, query: this.props.clearSearchOnClose ? '' : state.query };
         }
         this.setState(state);
         if (this.props.onValuesSelected !== undefined) {
@@ -211,14 +213,6 @@ export class TreeFilter extends React.PureComponent<ITreeFilterProps, ITreeFilte
 
     @autobind
     private onItemsSearch(query: string) {
-        /*
-         * no need to manually clear search because
-         * on every callout close inner component
-         * gets unmounted and its state reseted
-        */
-        if (this.props.clearSearchOnClose) {
-            return;
-        }
         this.setState({ ...this.state, query });
     }
 
@@ -228,6 +222,7 @@ export class TreeFilter extends React.PureComponent<ITreeFilterProps, ITreeFilte
         this.setState(prevState => ({
             ...prevState,
             isOpen: false,
+            query: this.props.clearSearchOnClose ? '' : prevState.query,
             selection: this.props.filterSelection,
             selectionText: selectionStrings.selectionText,
             titleText: selectionStrings.titleText
@@ -241,7 +236,10 @@ export class TreeFilter extends React.PureComponent<ITreeFilterProps, ITreeFilte
             this.props.onSave(this.props.filterId, this.state.selection);
         }
 
-        this.setState(prevState => ({ ...prevState, isOpen: false, selection: this.state.selection }));
+        this.setState(prevState => ({ ...prevState, 
+            isOpen: false, 
+            query: this.props.clearSearchOnClose ? '' : prevState.query,
+            selection: this.state.selection }));
         this.props.onCalloutClose();
     }
 

--- a/src/components/TreeFilter/VirtualizedTreeView.tsx
+++ b/src/components/TreeFilter/VirtualizedTreeView.tsx
@@ -64,7 +64,6 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
 
         this.allItemIds = this.props.allItemIdsGetter(props.items);
 
-        this.searchItems = _.debounce(this.searchItems, 100);
     }
 
     public componentWillMount() {
@@ -91,7 +90,8 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
     }
 
     public componentWillReceiveProps(nextProps: IVirtualizedTreeViewProps) {
-        if (nextProps.items !== this.props.items) {
+
+        if (nextProps.items !== this.props.items || this.state.searchText !== nextProps.searchQuery) {
             const filteredItems = ItemOperator.filterItems(nextProps.items, this.state.searchText);
             this.setState(
                 prevState => ({
@@ -145,7 +145,7 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
                     title && <label className="virtualized-tree-filter-title" title={ title }>{ title }</label>
                 }
                 {
-                    hasSearch && <Search labelText={ this.state.searchText } onChange={ this.searchItems } className="filter-search" />
+                    hasSearch && <Search value={ this.state.searchText } onChange={ this.searchItems } className="filter-search" />
                 }
                 {
                     !isSingleSelect && showSelectAll &&


### PR DESCRIPTION
The search text was never saved in the TreeFilter component, so when a rerender was triggered by the selection, the searchbox would reset to an empty value.  

Debounce was not needed because the textbox component has a debounce of its own. 

With both of the debounces sometimes the old typed text would show up, that is you would type and a letter would go missing just like that. Since the previously debounced text would be pushed up to the parent component it would trigger an update, and then it would update it with the old text.  
With the default 200ms debounce in the searchbox and the 100ms debounce outside of it it would sometimes overlap if you type fast.  
This only manifetested now that we provided the search box text from the outside. 

 