### PR TITLE
Bug/fix for null nested objects

### DIFF
--- a/examples/MockData/gridData.ts
+++ b/examples/MockData/gridData.ts
@@ -1,8 +1,6 @@
 import { GridColumn, DataTypeEnum, SortDirection, BoolFormatTypeEnum } from '../../src/components/QuickGrid/QuickGrid.Props';
 import { TreeNode, TreeDataSource } from '../../src/models/TreeData';
 
-
-
 const RANDOM_WORDS = ['abstrusity', 'advertisable', 'bellwood', 'benzole', 'disputative', 'djilas', 'ebracteate', 'zonary'];
 const RANDOM_Names = ['Ivan', 'Mario', 'Silvio', 'Hrvoje', 'Vinko', 'Marijana', 'Andrea'];
 const RANDOM_Color = ['Black', 'Green', 'White', 'Blue', 'Orange', 'Red', 'Yellow', 'Gray'];
@@ -72,8 +70,6 @@ export const generateTreeData = (size: number): TreeNode => {
     }
     let result: Array<TreeNode> = [];
 
-
-
     for (let i = 0; i < treeSize[0]; i++) {
         let treeEntry = generateTreeNode();
         for (let j = 0; j < treeSize[1]; j++) {
@@ -142,8 +138,6 @@ export const gridColumns1: Array<GridColumn> = [
     }
 ];
 
-
-
 export function getTreeGridData(size: number): TreeDataSource<GridData> {
     const treeData = new TreeDataSource<GridData>(generateTreeData(size));
     return treeData;
@@ -180,7 +174,8 @@ export const gridColumns2: Array<GridColumn> = [
     {
         valueMember: 'DummyObject.IsHere',
         headerText: 'DummyObject Property',
-        getCellValue: (rowData) => {return rowData.DummyObject.IsHere; },
+        // Null value should be handled on the definition side
+        getCellValue: (rowData) => { return rowData.DummyObject != null ? rowData.DummyObject.IsHere : false; },
         width: 100,
         dataType: DataTypeEnum.Boolean,
         boolFormatType: BoolFormatTypeEnum.TextOnly
@@ -211,7 +206,7 @@ export function getGridData(numberOfElements) {
                 Mixed: RANDOM_Mix[Math.floor(Math.random() * RANDOM_Mix.length)],
                 Numbers: Math.floor(Math.random() * 30),
                 IsUpdated: Math.random() >= 0.5,
-                DummyObject: {IsHere: Math.random() >= 0.5}
+                DummyObject: Math.random() >= 0.2 ? {IsHere: Math.random() >= 0.5} : null
             }
         );
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "quick-react-ts",
-    "version": "0.12.7",
+    "version": "0.12.8",
     "description": "Reusable components for React, written in TypeScript",
     "main": "./lib/index.js",
     "typings": "./lib/index",

--- a/src/components/QuickGrid/rowGrouper.ts
+++ b/src/components/QuickGrid/rowGrouper.ts
@@ -30,7 +30,8 @@ class RowGrouper {
         let columnName = groupByColumn.column;
         let column = _.find(this.columns, x => x.valueMember === columnName);
         let groupedRows = groupByColumnFunction(rows, column);
-        let groupKeys = _.uniq(_.map<any, string>(rows, columnName));
+        let groupMapper = (column.getCellValue || columnName) as string;
+        let groupKeys = _.uniq(_.map<any, string>(rows, groupMapper));
         let dataViewRows = [];
         for (let i = 0; i < groupKeys.length; i++) {
             let groupKeyValue = groupKeys[i];


### PR DESCRIPTION
Noticed that the grid sort/group and other actions are breaking if the nested object is null. 
So now I've made a change in a way that the grid is checking if the getCellValue is supplied and is using that to calculate sort/group and rest. 
That means that the user needs to handle what happens in case of null/undefined by means of function supplied