### PR TITLE
Custom tooltip content

### DIFF
--- a/src/components/Dropdown/Dropdown.Props.ts
+++ b/src/components/Dropdown/Dropdown.Props.ts
@@ -43,7 +43,7 @@ export interface IDropdownOption {
     selected?: boolean;
     href?: string;
     icon?: string;
-    tooltipInfo?: { title: string, content: string, directionalHint?: DirectionalHint; };
+    tooltipInfo?: { title: string, content: string | JSX.Element, directionalHint?: DirectionalHint; className?: string };
 }
 
 export enum DropdownType {

--- a/src/components/Tooltip/Tooltip.props.ts
+++ b/src/components/Tooltip/Tooltip.props.ts
@@ -2,7 +2,7 @@ import { DirectionalHint } from '../../utilities/DirectionalHint';
 
 export interface ITooltipProps {
     title?: string;
-    content: string;
+    content: string | JSX.Element;
     className?: string;
     targetElement?: HTMLElement;
     directionalHint?: DirectionalHint;


### PR DESCRIPTION
Besides string, tooltip content now can be any JSX Element.
Added className prop in Dropdown Tooltip as well, can be used to make custom looking tooltips in drowpdown.