### PR TITLE
On mount refresh partially checked nodes in VirtualizedTreeView

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "quick-react-ts",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "description": "Reusable components for React, written in TypeScript",
     "main": "./lib/index.js",
     "typings": "./lib/index",


### PR DESCRIPTION
Refreshes partially checked nodes in case items are organized as tree (not flat list) and if recursive selection is enabled. If not refreshed, all partially selected nodes appear as not selected.