### PR TITLE
Bug/refresh partially checked nodes on update

### DIFF
--- a/src/components/TreeFilter/VirtualizedTreeView.tsx
+++ b/src/components/TreeFilter/VirtualizedTreeView.tsx
@@ -73,9 +73,7 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
         const checkedItemIds = this.props.filterSelection.type === FilterSelectionEnum.All ? this.allItemIds : this.props.filterSelection.selectedIDs;
 
         if (this.props.filterSelection.type !== FilterSelectionEnum.All && checkedItemIds.length > 0) {
-            if (!this.props.itemsAreFlatList && this.props.enableRecursiveSelection) {
-                this.updatePartiallyCheckedItems(this.props.filterSelection.selectedIDs);
-            }
+            this.updatePartiallyCheckedItems(this.props.filterSelection.selectedIDs);
 
             scrollToIndex = this.state.filteredItems.findIndex((element) => {
                 return element.id === checkedItemIds[0];
@@ -117,11 +115,15 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
     }
 
     public componentDidUpdate(prevProps: ITreeFilterProps, prevState: IVirtualizedTreeViewState) {
-        if (this.state.filteredItems !== prevState.filteredItems) {
+        if (!_.isEqual(this.state.filteredItems, prevState.filteredItems)) {
             if (this._list != null) {
                 this._list.recomputeRowHeights();
             }
-        } else if (this.props.filterSelection.selectedIDs !== prevProps.filterSelection.selectedIDs) {
+        } else if (!_.isEqual(this.props.filterSelection.selectedIDs, prevProps.filterSelection.selectedIDs)) {
+            const checkedItemIds = this.props.filterSelection.type === FilterSelectionEnum.All ? this.allItemIds : this.props.filterSelection.selectedIDs;
+            if (this.props.filterSelection.type !== FilterSelectionEnum.All && checkedItemIds.length > 0) {
+                this.updatePartiallyCheckedItems(this.props.filterSelection.selectedIDs);
+            }
             if (this._list != null) {
                 this._list.forceUpdateGrid();
             }
@@ -478,6 +480,9 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
     }
 
     private updatePartiallyCheckedItems(checkedItemIds: Array<string>) {
+        if (this.props.itemsAreFlatList || !this.props.enableRecursiveSelection) {
+            return;
+        }
         const partiallyCheckedItemIds: Array<string> = [];
         let parents: Array<TreeItem> = [];
         checkedItemIds.forEach(itemId => {

--- a/src/components/TreeFilter/VirtualizedTreeView.tsx
+++ b/src/components/TreeFilter/VirtualizedTreeView.tsx
@@ -72,24 +72,26 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
         let scrollToIndex = undefined;
         const checkedItemIds = this.props.filterSelection.type === FilterSelectionEnum.All ? this.allItemIds : this.props.filterSelection.selectedIDs;
 
-        if (this.props.filterSelection.type !== FilterSelectionEnum.All && checkedItemIds.length > 0) {
+        if (this.props.filterSelection.type !== FilterSelectionEnum.All) {
             this.updatePartiallyCheckedItems(this.props.filterSelection.selectedIDs);
 
-            scrollToIndex = this.state.filteredItems.findIndex((element) => {
-                return element.id === checkedItemIds[0];
-            });
-            if (scrollToIndex === -1) {
-                // find the top level id of the nested checked item
-                let parent = this.parentLookup[checkedItemIds[0]];
-                while (parent !== undefined) {
-                    if (typeof parent.id === 'number') {
-                        scrollToIndex = parent.id;
-                        break;
+            if (checkedItemIds.length > 0) {
+                scrollToIndex = this.state.filteredItems.findIndex((element) => {
+                    return element.id === checkedItemIds[0];
+                });
+                if (scrollToIndex === -1) {
+                    // find the top level id of the nested checked item
+                    let parent = this.parentLookup[checkedItemIds[0]];
+                    while (parent !== undefined) {
+                        if (typeof parent.id === 'number') {
+                            scrollToIndex = parent.id;
+                            break;
+                        }
+                        parent = this.parentLookup[parent.id];
                     }
-                    parent = this.parentLookup[parent.id];
                 }
+                this.setState({ scrollToIndex });
             }
-            this.setState({ scrollToIndex });
         }
     }
 
@@ -115,17 +117,21 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
     }
 
     public componentDidUpdate(prevProps: ITreeFilterProps, prevState: IVirtualizedTreeViewState) {
+        let selectionChanged: Boolean = false;
         if (!_.isEqual(this.state.filteredItems, prevState.filteredItems)) {
+            selectionChanged = true;
             if (this._list != null) {
                 this._list.recomputeRowHeights();
             }
         } else if (!_.isEqual(this.props.filterSelection.selectedIDs, prevProps.filterSelection.selectedIDs)) {
-            const checkedItemIds = this.props.filterSelection.type === FilterSelectionEnum.All ? this.allItemIds : this.props.filterSelection.selectedIDs;
-            if (this.props.filterSelection.type !== FilterSelectionEnum.All && checkedItemIds.length > 0) {
-                this.updatePartiallyCheckedItems(this.props.filterSelection.selectedIDs);
-            }
+            selectionChanged = true;
             if (this._list != null) {
                 this._list.forceUpdateGrid();
+            }
+        }
+        if (selectionChanged) {
+            if (this.props.filterSelection.type !== FilterSelectionEnum.All) {
+                this.updatePartiallyCheckedItems(this.props.filterSelection.selectedIDs);
             }
         }
     }


### PR DESCRIPTION
Refreshes partially checked items on every update, even if none is selected (to uncheck partially checked item).
Used lodash deep compare for comparing filter selection, otherwise result of compare is always false.