### PR TITLE
Added options to delay closing and interacting with tooltop

### DIFF
--- a/examples/src/Tooltip.tsx
+++ b/examples/src/Tooltip.tsx
@@ -34,7 +34,18 @@ export class Index extends React.Component<any, any> {
                     </Tooltip>
                 </div>
                 <div style={{ marginLeft: '50px' }}>
-                    <Tooltip content={'This is error tooltip, because an error occured'} title={'Error tooltip title'}className={'tooltip-error'} directionalHint={DirectionalHint.rightCenter} >
+                    <Tooltip content={'This is error tooltip, because an error occured'} title={'Error tooltip title'} className={'tooltip-error'} directionalHint={DirectionalHint.rightCenter} >
+                        <Button>Hover Over Me</Button>
+                    </Tooltip>
+                </div>
+                <div style={{ marginLeft: '50px' }}>
+                    <Tooltip
+                        content={'This tooltip have delay and interaction capabilities'}
+                        title={'You can interact with me'}
+                        className={'tooltip-error'}
+                        directionalHint={DirectionalHint.rightCenter}
+                        closeDelayMs={500}
+                        >
                         <Button>Hover Over Me</Button>
                     </Tooltip>
                 </div>

--- a/src/components/Tooltip/Tooltip.props.ts
+++ b/src/components/Tooltip/Tooltip.props.ts
@@ -10,4 +10,5 @@ export interface ITooltipProps {
     onTooltipToggle?(isTooltipVisible: boolean): void;
     containerClass?: string;
     delayMs?: number;
+    closeDelayMs?: number;
 }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -11,6 +11,7 @@ export class Tooltip extends CommonComponent<ITooltipProps, any> {
     private _tooltipHost: HTMLElement;
 
     public timer = null;
+    private _closingTimer = null;
 
     public static defaultProps = {
         directionalHint: DirectionalHint.bottomCenter,
@@ -56,8 +57,8 @@ export class Tooltip extends CommonComponent<ITooltipProps, any> {
         return (
             <div
                 ref={this._resolveRef('_tooltipHost')}
-                { ...{ onFocusCapture: this._onTooltipMouseEnter } }
-                { ...{ onBlurCapture: this._onTooltipMouseLeave } }
+                {...{ onFocusCapture: this._onTooltipMouseEnter }}
+                {...{ onBlurCapture: this._onTooltipMouseLeave }}
                 onMouseEnter={this._onTooltipMouseEnter}
                 onMouseLeave={this._onTooltipMouseLeave}
                 onMouseUpCapture={this._onTooltipMouseLeave}
@@ -71,8 +72,15 @@ export class Tooltip extends CommonComponent<ITooltipProps, any> {
                         directionalHint={directionalHint}
                         className={tooltipClassName}
                         isBeakVisible={true}
-                        gapSpace={0}>
-                        <div className="tooltip-content" role="tooltip">
+                        gapSpace={0}
+                    >
+
+                        <div
+                            className="tooltip-content"
+                            role="tooltip"
+                            onMouseEnter={this._onTooltipMouseEnter}
+                            onMouseLeave={this._onTooltipMouseLeave}
+                        >
                             {title &&
                                 <div>
                                     <span className="tooltip-title">{title}</span>
@@ -97,7 +105,10 @@ export class Tooltip extends CommonComponent<ITooltipProps, any> {
             return;
         }
         this.timer = setTimeout(() => this._toggleTooltip(true), this.props.delayMs);
+        clearTimeout(this._closingTimer);
     }
+
+
 
     // Hide Tooltip
     @autobind
@@ -107,7 +118,15 @@ export class Tooltip extends CommonComponent<ITooltipProps, any> {
                 clearTimeout(this.timer);
             }
 
-            this._toggleTooltip(false);
+            if (this.props.closeDelayMs) {
+               clearTimeout(this._closingTimer);
+
+                this._closingTimer = setTimeout(() => {
+                    this._toggleTooltip(false);
+                }, this.props.closeDelayMs);
+            } else {
+                this._toggleTooltip(false);
+            }
         }
     }
 


### PR DESCRIPTION
Added closeDelayMs prop to Tooltip class.
This enables us to delay closing the Tooltip as well as interacting with content in tooltip, as mouseEnter on tooltip content will now keep the tooltip open.