### PR TITLE
LeftNav expand delay fix

### DIFF
--- a/src/components/LeftNavigation/LeftNavigation.tsx
+++ b/src/components/LeftNavigation/LeftNavigation.tsx
@@ -106,7 +106,7 @@ export class LeftNavigation extends CommonComponent<ILeftNavigationProps, any> {
 
     @autobind
     private setNavigationOpenState() {
-        if (this.props.expandDelayMs && this.timer === null) {
+        if (this.props.expandCaptionsBehavior === ExpandCaptionsBehaviorEnum.ShowCaptionsOnHover && this.props.expandDelayMs && this.timer === null) {
             return;
         }
         this.setState({ isOpen: !this.state.isOpen });

--- a/src/components/LeftNavigation/LeftNavigation.tsx
+++ b/src/components/LeftNavigation/LeftNavigation.tsx
@@ -86,7 +86,8 @@ export class LeftNavigation extends CommonComponent<ILeftNavigationProps, any> {
 
     @autobind
     private onNavigationMouseOut() {
-        if (this.props.expandCaptionsBehavior === ExpandCaptionsBehaviorEnum.ShowCaptionsOnHover && this.state.isOpen) {
+        if (this.props.expandCaptionsBehavior === ExpandCaptionsBehaviorEnum.ShowCaptionsOnHover && (this.state.isOpen || this.timer !== null)) {
+            this.timer = null;
             this.setState({ isOpen: false });
         }
     }
@@ -105,8 +106,10 @@ export class LeftNavigation extends CommonComponent<ILeftNavigationProps, any> {
 
     @autobind
     private setNavigationOpenState() {
+        if (this.props.expandDelayMs && this.timer === null) {
+            return;
+        }
         this.setState({ isOpen: !this.state.isOpen });
-
         this.timer = null;
     }
 

--- a/src/components/LeftNavigation/LeftNavigation.tsx
+++ b/src/components/LeftNavigation/LeftNavigation.tsx
@@ -86,7 +86,8 @@ export class LeftNavigation extends CommonComponent<ILeftNavigationProps, any> {
 
     @autobind
     private onNavigationMouseOut() {
-        if (this.props.expandCaptionsBehavior === ExpandCaptionsBehaviorEnum.ShowCaptionsOnHover && (this.state.isOpen || this.timer !== null)) {
+        if (this.props.expandCaptionsBehavior === ExpandCaptionsBehaviorEnum.ShowCaptionsOnHover && 
+        (this.state.isOpen || this.timer !== null)) {
             this.timer = null;
             this.setState({ isOpen: false });
         }

--- a/src/components/LeftNavigation/LeftNavigation.tsx
+++ b/src/components/LeftNavigation/LeftNavigation.tsx
@@ -107,7 +107,8 @@ export class LeftNavigation extends CommonComponent<ILeftNavigationProps, any> {
 
     @autobind
     private setNavigationOpenState() {
-        if (this.props.expandCaptionsBehavior === ExpandCaptionsBehaviorEnum.ShowCaptionsOnHover && this.props.expandDelayMs && this.timer === null) {
+        if (this.props.expandCaptionsBehavior === ExpandCaptionsBehaviorEnum.ShowCaptionsOnHover &&
+         this.props.expandDelayMs && this.timer === null) {
             return;
         }
         this.setState({ isOpen: !this.state.isOpen });


### PR DESCRIPTION
IsOpen state is reset if LeftNavigation is hovered over quickly: making sure LeftNavigation is not left open after MouseOut.