### PR TITLE
Added default height so this component can be tested

### DIFF
--- a/src/components/TreeFilter/VirtualizedTreeView.tsx
+++ b/src/components/TreeFilter/VirtualizedTreeView.tsx
@@ -173,8 +173,8 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
                 <AutoSizer>
                     {({ width, height }) => (
                         <List
-                            height={this.getListHeight(height)}
-                            width={width}
+                            height={this.getListHeight(height || 100)}
+                            width={width || 100}
                             overscanRowCount={10}
                             ref={this.setListReference}
                             rowHeight={this.rowHeight}


### PR DESCRIPTION
Added min height so TreeFilter will be testable in enzyme. Problem was that in JSDOM height of the element wasn't setting, so no filter options were being rendered.