### PR TITLE
Feat/icon with number

### DIFF
--- a/examples/src/LeftNavigation.tsx
+++ b/examples/src/LeftNavigation.tsx
@@ -6,12 +6,14 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 import { LeftNavigation } from './../../src/components/LeftNavigation/LeftNavigation';
-import { ExpandCaptionsBehaviorEnum, LeftNavigationOptionPositionEnum } from '../../src/index';
+import { ExpandCaptionsBehaviorEnum, LeftNavigationOptionPositionEnum, NotificationBubbleStyleObject } from '../../src/index';
+
+const styleObject: NotificationBubbleStyleObject = { bubbleStyleObject: {backgroundColor: 'orange'}};
 
 const options = [
     { text: 'Home page', id: 'Home', href: 'http://Acceleratio.net', icon: 'icon-help' },
     { text: 'Activity', id: 'Activity', href: '#1', disabled: true, icon: 'icon-account' },
-    { text: 'News', id: 'News', href: '#2', icon: 'icon-add', notificationNumber: 15 },
+    { text: 'News', id: 'News', href: '#2', icon: 'icon-add', notificationNumber: 15, notificationBubbleStyleObject: styleObject },
     { text: 'Documents library', id: 'Documents', href: '#3', selected: true, icon: 'icon-alert', notificationNumber: 7 },
     { text: 'Books', id: 'Books', href: '#4', icon: 'icon-trash', position: LeftNavigationOptionPositionEnum.Down }
 ];

--- a/examples/src/LeftNavigation.tsx
+++ b/examples/src/LeftNavigation.tsx
@@ -24,6 +24,7 @@ export class Index extends React.Component<any, any> {
 
 
     public render() {
+        const defaultStyleObject: NotificationBubbleStyleObject = { bubbleStyleObject: {backgroundColor: 'purple'}};
         return (
             <div style={{ display: 'flex', justifyContent: 'space-between', maxWidth: 1000 }}>
                 <div style={{ height: 500, width: 200 }}>
@@ -39,6 +40,7 @@ export class Index extends React.Component<any, any> {
                         id={'leftNavigation'}
                         options={options}
                         expandCaptionsBehavior={ExpandCaptionsBehaviorEnum.ShowCaptionsOnToggleButton}
+                        notificationBubbleStyleObject={defaultStyleObject}
                     />
                 </div>
                 <div style={{ height: 500, width: 200 }}>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quick-react-ts",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "description": "Reusable components for React, written in TypeScript",
   "main": "./lib/index.js",
   "typings": "./lib/index",

--- a/src/components/LeftNavigation/LeftNavigation.Props.ts
+++ b/src/components/LeftNavigation/LeftNavigation.Props.ts
@@ -15,7 +15,6 @@ export interface ILeftNavigationProps {
     className?: string;
     onClick?: (ev?: React.MouseEvent<HTMLElement>, item?: ILeftNavigationOption) => void;
     expandCaptionsBehavior?: ExpandCaptionsBehaviorEnum;
-    notificationBubbleStyleObject?: NotificationBubbleStyleObject;
     expandMargin?: boolean;
     expandDelayMs?: number;
 }
@@ -29,6 +28,7 @@ export interface ILeftNavigationOption {
     disabled?: boolean;
     position?: LeftNavigationOptionPositionEnum;
     notificationNumber?: number;
+    notificationBubbleStyleObject?: NotificationBubbleStyleObject;
 }
 
 export enum LeftNavigationOptionPositionEnum {

--- a/src/components/LeftNavigation/LeftNavigation.Props.ts
+++ b/src/components/LeftNavigation/LeftNavigation.Props.ts
@@ -17,6 +17,7 @@ export interface ILeftNavigationProps {
     expandCaptionsBehavior?: ExpandCaptionsBehaviorEnum;
     expandMargin?: boolean;
     expandDelayMs?: number;
+    notificationBubbleStyleObject?: NotificationBubbleStyleObject;
 }
 
 export interface ILeftNavigationOption {

--- a/src/components/LeftNavigation/LeftNavigation.tsx
+++ b/src/components/LeftNavigation/LeftNavigation.tsx
@@ -136,7 +136,7 @@ export class LeftNavigation extends CommonComponent<ILeftNavigationProps, any> {
                     <a id={option.id}>
                         {(option.notificationNumber) ?
                             <NotificationIcon iconName={option.icon} notificationNumber={option.notificationNumber}
-                                notificationBubbleStyleObject={this.props.notificationBubbleStyleObject} />
+                                notificationBubbleStyleObject={option.notificationBubbleStyleObject} />
                             : <Icon iconName={option.icon} />}
                         <span className={spanClasses} >{option.text}</span>
                     </a>

--- a/src/components/LeftNavigation/LeftNavigation.tsx
+++ b/src/components/LeftNavigation/LeftNavigation.tsx
@@ -136,7 +136,8 @@ export class LeftNavigation extends CommonComponent<ILeftNavigationProps, any> {
                     <a id={option.id}>
                         {(option.notificationNumber) ?
                             <NotificationIcon iconName={option.icon} notificationNumber={option.notificationNumber}
-                                notificationBubbleStyleObject={option.notificationBubbleStyleObject} />
+                                notificationBubbleStyleObject={option.notificationBubbleStyleObject ? option.notificationBubbleStyleObject
+                                    : this.props.notificationBubbleStyleObject} />
                             : <Icon iconName={option.icon} />}
                         <span className={spanClasses} >{option.text}</span>
                     </a>


### PR DESCRIPTION
NotificationBubbleStyleObject was removed from ILeftNavigationProps and added to ILeftNavigationOptions so that every option can have different style object for notification number.