### PR TITLE
configured importHelpers flag in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     ],
     "typeRoots": [
       "node_modules/@types"
-    ]
+    ],
+    "importHelpers": true
   },
   "filesGlob": [
     "typings/index.d.ts",


### PR DESCRIPTION
Added impotHelpers flag to tsconfig. This is to help with the support for browsers, configurations and environments that do not support decorators and similar JavaScript functionalities