### PR TITLE
People picker principal min height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quick-react-ts",
-  "version": "0.13.23",
+  "version": "0.13.24",
   "description": "Reusable components for React, written in TypeScript",
   "main": "./lib/index.js",
   "typings": "./lib/index",

--- a/src/components/PeoplePicker/Principal.scss
+++ b/src/components/PeoplePicker/Principal.scss
@@ -2,7 +2,7 @@
 
 %principal-container{
     padding: 3px 5px 4px 10px;
-    min-height: 19px;
+    min-height: fit-content;
     border-radius: 8px;
     cursor: default;
     display: inline-flex;


### PR DESCRIPTION
When the item in suggestion list of people picker has a very long name, so long that it needs to be written in two rows, the span that contains it does not expand enough to encompass it. For this reason, min height is set to fit-content.  
