### PR TITLE
Feat/tree filter double click

### DIFF
--- a/examples/src/TreeFilter.tsx
+++ b/examples/src/TreeFilter.tsx
@@ -272,6 +272,23 @@ export class Index extends React.Component<any, DemoState> {
                     isReady={ false }
                     showResetButton={false}
                 />
+
+                <br /><br />
+
+                <p>TreeFilter with enabled expand on double click</p>
+                <TreeFilter
+                    filterId={'f12'}
+                    items={customTooltipContent}
+                    defaultSelection={FilterSelectionEnum.All}
+                    // tslint:disable-next-line:no-string-literal
+                    filterSelection={this.state.filterStates['f12']}
+                    enableRecursiveSelection={false}
+                    hasTitleBorder={true}
+                    showButtons={false}
+                    onValuesSelected={this.onValuesSelected}
+                    onSave={this.onSave}
+                    shouldGroupExpandOnDoubleClick={true}
+                />
             </div>
         );
     }

--- a/examples/src/TreeFilter.tsx
+++ b/examples/src/TreeFilter.tsx
@@ -109,8 +109,6 @@ export class Index extends React.Component<any, DemoState> {
                     maxHeight={500}
                     onItemExpand={this.onAsyncTreeItemExpand}
                     onCalloutClose={() => console.log('closing...')}
-                    isSingleSelect={true}
-                    isGroupSelectableOnSingleSelect={false}
                 />
                 <br /><br />
 
@@ -133,7 +131,7 @@ export class Index extends React.Component<any, DemoState> {
                     onItemExpand={this.onItemExpand}
                     onValuesSelected={this.onValuesSelected}
                     isSingleSelect={true}
-                    isGroupSelectableOnSingleSelect={false}
+                    isGroupSelectableOnSingleSelect={true}
                     // tslint:disable-next-line:no-string-literal
                     filterSelection={this.state.filterStates['f3']}
                     defaultSelection={FilterSelectionEnum.All}

--- a/examples/src/TreeFilter.tsx
+++ b/examples/src/TreeFilter.tsx
@@ -109,6 +109,8 @@ export class Index extends React.Component<any, DemoState> {
                     maxHeight={500}
                     onItemExpand={this.onAsyncTreeItemExpand}
                     onCalloutClose={() => console.log('closing...')}
+                    isSingleSelect={true}
+                    isGroupSelectableOnSingleSelect={false}
                 />
                 <br /><br />
 
@@ -131,7 +133,7 @@ export class Index extends React.Component<any, DemoState> {
                     onItemExpand={this.onItemExpand}
                     onValuesSelected={this.onValuesSelected}
                     isSingleSelect={true}
-                    isGroupSelectableOnSingleSelect={true}
+                    isGroupSelectableOnSingleSelect={false}
                     // tslint:disable-next-line:no-string-literal
                     filterSelection={this.state.filterStates['f3']}
                     defaultSelection={FilterSelectionEnum.All}

--- a/src/components/TreeFilter/TreeFilter.Props.ts
+++ b/src/components/TreeFilter/TreeFilter.Props.ts
@@ -29,6 +29,7 @@ export interface ITreeFilterProps {
     hasSearch?: boolean;
     isSingleSelect?: boolean;
     isGroupSelectableOnSingleSelect?: boolean;
+    shouldGroupExpandOnDoubleClick?: boolean;
     enableRecursiveSelection?: boolean;
     itemsAreFlatList?: boolean;
     onValuesSelected?: (filterId: string, filterSelection: IFilterSelection) => void;
@@ -73,6 +74,7 @@ export const defaultTreeFilterProps: Partial<ITreeFilterProps> = {
     isSingleSelect: false,
     itemsAreFlatList: false,
     isGroupSelectableOnSingleSelect: false,
+    shouldGroupExpandOnDoubleClick: false,
     enableRecursiveSelection: true,
     directionalHint: DirectionalHint.bottomRightEdge,
     filterSelection: { type: FilterSelectionEnum.None, selectedIDs: [] },

--- a/src/components/TreeFilter/VirtualizedTreeView.Props.ts
+++ b/src/components/TreeFilter/VirtualizedTreeView.Props.ts
@@ -13,6 +13,7 @@ export interface IVirtualizedTreeViewProps {
     onSave?: () => void;
     onCancel?: () => void;
     isGroupSelectableOnSingleSelect?: boolean;
+    shouldGroupExpandOnDoubleClick?: boolean;
     enableRecursiveSelection?: boolean;
     itemsAreFlatList?: boolean;
     onValuesSelected?: (filterId: string, filterSelection: IFilterSelection) => void;
@@ -33,6 +34,7 @@ export const defaultTreeProps: Partial<IVirtualizedTreeViewProps> = {
     isSingleSelect: false,
     itemsAreFlatList: false,
     isGroupSelectableOnSingleSelect: false,
+    shouldGroupExpandOnDoubleClick: false,
     enableRecursiveSelection: true,
     onValuesSelected: () => { },
     filterSelection: { type: FilterSelectionEnum.None, selectedIDs: [] },

--- a/src/components/TreeFilter/VirtualizedTreeView.tsx
+++ b/src/components/TreeFilter/VirtualizedTreeView.tsx
@@ -250,13 +250,16 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
         const itemChecked = this.isItemInList(checkedItemIds, treeItem);
         const itemCheckedOrAllFilteredChecked = itemChecked || (this.state.searchText !== '' && this.allFilteredChildrenChecked(treeItem, checkedItemIds));
 
+        //#region Item click events
+
+        // used with double click events, so we don't trigger both the single click action, and the double click if double click is enabled
         let doubleClickTimer;
         let doubleClickDelay = 200;
         let preventSingleClick = false;
 
         const onItemCheckedChange = () => {
             const onItemCheckedChangeAction = () => {
-                if (preventSingleClick) {
+                if (this.props.shouldGroupExpandOnDoubleClick && preventSingleClick) {
                     return;
                 }
 
@@ -265,16 +268,12 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
                 preventSingleClick = false;
             };
 
-            if (this.props.shouldGroupExpandOnDoubleClick) {
-                doubleClickTimer = setTimeout(onItemCheckedChangeAction, doubleClickDelay);
-            } else {
-                onItemCheckedChangeAction();
-            }
+            onItemClicked(onItemCheckedChangeAction);
         };
 
         const onSingleSelectItemClick = () => {
             const onSingleClickAction = () => {
-                if (this.props.isGroupSelectableOnSingleSelect === false && itemHasChildren(treeItem) || preventSingleClick) {
+                if (this.props.isGroupSelectableOnSingleSelect === false && itemHasChildren(treeItem) || this.props.shouldGroupExpandOnDoubleClick && preventSingleClick) {
                     return;
                 }
                 
@@ -282,10 +281,14 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
                 preventSingleClick = false;
             };
 
+            onItemClicked(onSingleClickAction);
+        };
+
+        const onItemClicked = (singleClickedAction: () => void) => {
             if (this.props.shouldGroupExpandOnDoubleClick) {
-                doubleClickTimer = setTimeout(onSingleClickAction, doubleClickDelay);
+                doubleClickTimer = setTimeout(singleClickedAction, doubleClickDelay);
             } else {
-                onSingleClickAction();
+                singleClickedAction();
             }
         };
 
@@ -296,6 +299,7 @@ export class VirtualizedTreeView extends React.PureComponent<IVirtualizedTreeVie
                 onExpandClick(event);
             }
         };
+        //#endregion
 
         // tslint:disable-next-line:variable-name
         const ItemCheckboxElement = () => {

--- a/src/components/TreeFilter/VirtualizedTreeViewCheckBox.tsx
+++ b/src/components/TreeFilter/VirtualizedTreeViewCheckBox.tsx
@@ -15,11 +15,12 @@ export interface IVirtualizedTreeViewCheckBoxProps {
     style?: React.CSSProperties;
     iconTooltipContent?: string;
     onChange: (e: any) => void;
+    onDoubleClick?: (e: any) => void;
 }
 
 export class VirtualizedTreeViewCheckBox extends React.PureComponent<IVirtualizedTreeViewCheckBoxProps, {}> {
     render() {
-        const { itemId, checked, onChange, text, iconName, iconClassName, iconTooltipContent, style } = this.props;
+        const { itemId, checked, onChange, onDoubleClick, text, iconName, iconClassName, iconTooltipContent, style } = this.props;
         const isChecked = checked === CheckStatus.Checked;
 
         const virtualizedTreeClassName = classNames(
@@ -31,7 +32,7 @@ export class VirtualizedTreeViewCheckBox extends React.PureComponent<IVirtualize
         );
 
         return (
-            <div className={virtualizedTreeClassName} onClick={onChange} style={style}>
+            <div className={virtualizedTreeClassName} onClick={onChange} onDoubleClick={onDoubleClick} style={style}>
                 <input {...isChecked} className={'checkbox-input'} type="checkbox" />
                 {isChecked && <Icon className={'virtualized-tree-filter-checkbox-checkmark'} iconName={'icon-checkmark'} />}
                 <label className={classNames('virtualized-tree-filter-checkbox-label', { 'is-checked': isChecked })} >


### PR DESCRIPTION
Added expansion on double click. By default this behavior is turned off, and can be enabled by setting the shouldGroupExpandOnDoubleClick flag to true. Works for both single and multiselect:

https://monosnap.com/file/ABKhtN6cqzp4FaZH9TMrs3F3HnDYdr