### PR TITLE
Fix/case insensitive sorting

### DIFF
--- a/src/components/QuickGrid/rowGrouper.ts
+++ b/src/components/QuickGrid/rowGrouper.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 import { GroupRow, IGroupBy, GridColumn } from './QuickGrid.Props';
 import { groupByColumn as groupByColumnFunction  } from '../../utilities/array';
-import { resolveCellValueForDisplay } from '../../utilities/resolveCellValue';
+import { resolveCellValueForDisplay, resolveCellValue } from '../../utilities/resolveCellValue';
 
 class RowGrouper {
     groupByColumns: Array<IGroupBy>;
@@ -30,8 +30,7 @@ class RowGrouper {
         let columnName = groupByColumn.column;
         let column = _.find(this.columns, x => x.valueMember === columnName);
         let groupedRows = groupByColumnFunction(rows, column);
-        let groupMapper = (column.getCellValue || columnName) as string;
-        let groupKeys = _.uniq(_.map<any, string>(rows, groupMapper));
+        let groupKeys = _.uniq(_.map<any, string>(rows, row => resolveCellValue(row, column)));
         let dataViewRows = [];
         for (let i = 0; i < groupKeys.length; i++) {
             let groupKeyValue = groupKeys[i];

--- a/src/components/TreeGrid/TreeGridDataSelectors.ts
+++ b/src/components/TreeGrid/TreeGridDataSelectors.ts
@@ -120,6 +120,10 @@ const sort = (input, sortDirection, sortColumn, valueGetterForSort) => {
             valueA = a[sortColumnFinal];
             valueB = b[sortColumnFinal];
         }
+        if (typeof valueA === 'string' && typeof valueB === 'string') {
+            valueA = valueA.toLowerCase();
+            valueB = valueB.toLowerCase();
+        }
         if (valueA < valueB) {
             return -1 * sortModifier;
         }
@@ -129,6 +133,10 @@ const sort = (input, sortDirection, sortColumn, valueGetterForSort) => {
         sortColumnFinal = 'treeId';
         valueA = a[sortColumnFinal];
         valueB = b[sortColumnFinal];
+        if (typeof valueA === 'string' && typeof valueB === 'string') {
+            valueA = valueA.toLowerCase();
+            valueB = valueB.toLowerCase();
+        }
         if (valueA < valueB) {
             return -1 * sortModifier;
         }

--- a/src/components/TreeGrid/TreeGridDataSelectors.ts
+++ b/src/components/TreeGrid/TreeGridDataSelectors.ts
@@ -108,37 +108,22 @@ const sort = (input, sortDirection, sortColumn, valueGetterForSort) => {
         return input;
     }
     const sortModifier = sortDirection === SortDirection.Descending ? -1 : 1;
+    const collator = Intl.Collator([...navigator.languages], {sensitivity: 'accent'});
     const sortFunction = (a, b) => {
         let compare = 0;
         if (valueGetterForSort) {
-            compare = lowerCaseCompare(valueGetterForSort(a), valueGetterForSort(b));
+            compare = collator.compare(valueGetterForSort(a), valueGetterForSort(b));
         } else {
-            compare = lowerCaseCompare(a[sortColumn], b[sortColumn]);
+            compare = collator.compare(a[sortColumn], b[sortColumn]);
         }
         if (compare !== 0) {
             return compare * sortModifier;
         }
         const sortColumnFinal = 'treeId';
-        return lowerCaseCompare(a[sortColumnFinal], b[sortColumnFinal])
+        return collator.compare(a[sortColumnFinal], b[sortColumnFinal]) * sortModifier;
     };
     input.sort(sortFunction);
 };
-
-function lowerCaseCompare(a: any, b: any) {
-    let lA = a;
-    let lB = b;
-    if (typeof lA === 'string' && typeof lB === 'string') {
-        lA = a.toLowerCase();
-        lB = b.toLowerCase();
-    }
-    if (lA < lB) {
-        return -1;
-    }
-    if (lA > lB) {
-        return 1;
-    }
-    return 0;
-}
 
 function filterNodes(root: AugmentedTreeNode, filterText: string, columns: Array<string>);
 function filterNodes(root: AugmentedTreeNode, nodeFilterFunc: (node: AugmentedTreeNode) => boolean);

--- a/src/components/TreeGrid/TreeGridDataSelectors.ts
+++ b/src/components/TreeGrid/TreeGridDataSelectors.ts
@@ -108,7 +108,7 @@ const sort = (input, sortDirection, sortColumn, valueGetterForSort) => {
         return input;
     }
     const sortModifier = sortDirection === SortDirection.Descending ? -1 : 1;
-    const collator = Intl.Collator([...navigator.languages], {sensitivity: 'accent'});
+    const collator = Intl.Collator([...navigator.languages], {sensitivity: 'accent', numeric: true});
     const sortFunction = (a, b) => {
         let compare = 0;
         if (valueGetterForSort) {

--- a/src/components/TreeGrid/TreeGridDataSelectors.ts
+++ b/src/components/TreeGrid/TreeGridDataSelectors.ts
@@ -109,44 +109,36 @@ const sort = (input, sortDirection, sortColumn, valueGetterForSort) => {
     }
     const sortModifier = sortDirection === SortDirection.Descending ? -1 : 1;
     const sortFunction = (a, b) => {
-
-        let sortColumnFinal = sortColumn;
-        let valueA;
-        let valueB;
+        let compare = 0;
         if (valueGetterForSort) {
-            valueA = valueGetterForSort(a);
-            valueB = valueGetterForSort(b);
+            compare = lowerCaseCompare(valueGetterForSort(a), valueGetterForSort(b));
         } else {
-            valueA = a[sortColumnFinal];
-            valueB = b[sortColumnFinal];
+            compare = lowerCaseCompare(a[sortColumn], b[sortColumn]);
         }
-        if (typeof valueA === 'string' && typeof valueB === 'string') {
-            valueA = valueA.toLowerCase();
-            valueB = valueB.toLowerCase();
+        if (compare !== 0) {
+            return compare * sortModifier;
         }
-        if (valueA < valueB) {
-            return -1 * sortModifier;
-        }
-        if (valueA > valueB) {
-            return 1 * sortModifier;
-        }
-        sortColumnFinal = 'treeId';
-        valueA = a[sortColumnFinal];
-        valueB = b[sortColumnFinal];
-        if (typeof valueA === 'string' && typeof valueB === 'string') {
-            valueA = valueA.toLowerCase();
-            valueB = valueB.toLowerCase();
-        }
-        if (valueA < valueB) {
-            return -1 * sortModifier;
-        }
-        if (valueA > valueB) {
-            return 1 * sortModifier;
-        }
-        return 0;
+        const sortColumnFinal = 'treeId';
+        return lowerCaseCompare(a[sortColumnFinal], b[sortColumnFinal])
     };
     input.sort(sortFunction);
 };
+
+function lowerCaseCompare(a: any, b: any) {
+    let lA = a;
+    let lB = b;
+    if (typeof lA === 'string' && typeof lB === 'string') {
+        lA = a.toLowerCase();
+        lB = b.toLowerCase();
+    }
+    if (lA < lB) {
+        return -1;
+    }
+    if (lA > lB) {
+        return 1;
+    }
+    return 0;
+}
 
 function filterNodes(root: AugmentedTreeNode, filterText: string, columns: Array<string>);
 function filterNodes(root: AugmentedTreeNode, nodeFilterFunc: (node: AugmentedTreeNode) => boolean);

--- a/src/components/TreeGrid/TreeGridDataSelectors.ts
+++ b/src/components/TreeGrid/TreeGridDataSelectors.ts
@@ -109,18 +109,31 @@ const sort = (input, sortDirection, sortColumn, valueGetterForSort) => {
     }
     const sortModifier = sortDirection === SortDirection.Descending ? -1 : 1;
     const collator = Intl.Collator([...navigator.languages], {sensitivity: 'accent', numeric: true});
+    const comparer = (a, b) => {
+        if (typeof a === 'string' && typeof b === 'string') {
+            return collator.compare(a, b);
+        } else {
+            if (a < b) {
+                return -1;
+            }
+            if (a > b) {
+                return 1;
+            }
+        }
+        return 0;
+    };
     const sortFunction = (a, b) => {
         let compare = 0;
         if (valueGetterForSort) {
-            compare = collator.compare(valueGetterForSort(a), valueGetterForSort(b));
+            compare = comparer(valueGetterForSort(a), valueGetterForSort(b));
         } else {
-            compare = collator.compare(a[sortColumn], b[sortColumn]);
+            compare = comparer(a[sortColumn], b[sortColumn]);
         }
         if (compare !== 0) {
             return compare * sortModifier;
         }
         const sortColumnFinal = 'treeId';
-        return collator.compare(a[sortColumnFinal], b[sortColumnFinal]) * sortModifier;
+        return comparer(a[sortColumnFinal], b[sortColumnFinal]) * sortModifier;
     };
     input.sort(sortFunction);
 };

--- a/src/utilities/array.ts
+++ b/src/utilities/array.ts
@@ -33,6 +33,7 @@ export interface SortProps {
 }
 
 export const sortRowsByColumn = (rows: Array<any>, sortOptions: Array<SortProps>) => {
+    const collator = Intl.Collator([...navigator.languages], {sensitivity: 'accent'});
     const sortFunction = (a, b) => {
         for (let sortOption of sortOptions) {
             let valueA;
@@ -45,15 +46,13 @@ export const sortRowsByColumn = (rows: Array<any>, sortOptions: Array<SortProps>
                 valueB = resolveCellValue(b, sortOption.column);
 
             }
-            if (valueA < valueB) {
-                return -1 * sortOption.sortModifier;
+            const compare = collator.compare(valueA, valueB);
+            if (compare !== 0) {
+                return compare * sortOption.sortModifier;
             }
-            if (valueA > valueB) {
-                return 1 * sortOption.sortModifier;
-            }
+            return 0;
         }
-        return 0;
-    };
+    }
     return [...rows].sort(sortFunction);
 };
 

--- a/src/utilities/array.ts
+++ b/src/utilities/array.ts
@@ -42,7 +42,6 @@ export const sortRowsByColumn = (rows: Array<any>, sortOptions: Array<SortProps>
             } else {
                 valueA = resolveCellValue(a, sortOption.column);
                 valueB = resolveCellValue(b, sortOption.column);
-
             }
             let compare;
             if (typeof valueA === 'string' && typeof valueB === 'string') {
@@ -58,8 +57,8 @@ export const sortRowsByColumn = (rows: Array<any>, sortOptions: Array<SortProps>
             if (compare !== 0) {
                 return compare * sortOption.sortModifier;
             }
-            return 0;
         }
+        return 0;
     }
     return [...rows].sort(sortFunction);
 };

--- a/src/utilities/array.ts
+++ b/src/utilities/array.ts
@@ -1,6 +1,4 @@
-import { getObjectValue } from './getObjectValue';
 import { resolveCellValue } from './resolveCellValue';
-import { GridColumn } from '../components/QuickGrid';
 
 export function findIndex<T>(array: Array<T>, predicate: (item: T, index?: number) => boolean): number {
     let index = -1;
@@ -46,7 +44,17 @@ export const sortRowsByColumn = (rows: Array<any>, sortOptions: Array<SortProps>
                 valueB = resolveCellValue(b, sortOption.column);
 
             }
-            const compare = collator.compare(valueA, valueB);
+            let compare;
+            if (typeof valueA === 'string' && typeof valueB === 'string') {
+                compare = collator.compare(valueA, valueB);
+            } else {
+                if (valueA < valueB) {
+                    compare = -1;
+                }
+                if (valueA > valueB) {
+                    compare = 1;
+                }
+            }
             if (compare !== 0) {
                 return compare * sortOption.sortModifier;
             }

--- a/src/utilities/array.ts
+++ b/src/utilities/array.ts
@@ -33,7 +33,7 @@ export interface SortProps {
 }
 
 export const sortRowsByColumn = (rows: Array<any>, sortOptions: Array<SortProps>) => {
-    const collator = Intl.Collator([...navigator.languages], {sensitivity: 'accent'});
+    const collator = Intl.Collator([...navigator.languages], {sensitivity: 'accent', numeric: true});
     const sortFunction = (a, b) => {
         for (let sortOption of sortOptions) {
             let valueA;

--- a/src/utilities/resolveCellValue.ts
+++ b/src/utilities/resolveCellValue.ts
@@ -1,12 +1,8 @@
 import { GridColumn } from '../components/QuickGrid';
 
 export let resolveCellValue = (rowData: any, cell: GridColumn) => {
-    const value = cell.getCellValue !== undefined ? 
+    return cell.getCellValue !== undefined ? 
         cell.getCellValue(rowData) : rowData[cell.valueMember];
-    if (typeof value === 'string') {
-        return value.toLowerCase();
-    }
-    return value;
 };
 
 export let resolveCellValueForDisplay = (rowData: any, cell: GridColumn) => {

--- a/src/utilities/resolveCellValue.ts
+++ b/src/utilities/resolveCellValue.ts
@@ -1,8 +1,12 @@
 import { GridColumn } from '../components/QuickGrid';
 
 export let resolveCellValue = (rowData: any, cell: GridColumn) => {
-    return cell.getCellValue !== undefined ?
+    const value = cell.getCellValue !== undefined ? 
         cell.getCellValue(rowData) : rowData[cell.valueMember];
+    if (typeof value === 'string') {
+        return value.toLowerCase();
+    }
+    return value;
 };
 
 export let resolveCellValueForDisplay = (rowData: any, cell: GridColumn) => {


### PR DESCRIPTION
- used Intl.Collator for minimal performance impact (https://jsperf.com/sort-locale-strings/5)
- groupBy rows now correctly use same methods to resolve value as cells